### PR TITLE
Faster and Cleaner Object.merge implementation

### DIFF
--- a/Source/Class/Class.js
+++ b/Source/Class/Class.js
@@ -82,7 +82,9 @@ var implement = function(key, value, retain){
 		if (value.$hidden) return this;
 		this.prototype[key] = (retain) ? value : wrap(this, key, value);
 	} else {
-		Object.merge(this.prototype, key, value);
+		var obj = {};
+		obj[key] = value;
+		Object.merge(this.prototype, obj);
 	}
 
 	return this;

--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -337,27 +337,24 @@ Array.implement('clone', function(){
 	return clone;
 });
 
-var mergeOne = function(source, key, current){
-	switch (typeOf(current)){
-		case 'object':
-			if (typeOf(source[key]) == 'object') Object.merge(source[key], current);
-			else source[key] = Object.clone(current);
-		break;
-		case 'array': source[key] = current.clone(); break;
-		default: source[key] = current;
-	}
-	return source;
-};
-
 Object.extend({
 
-	merge: function(source, k, v){
-		if (typeOf(k) == 'string') return mergeOne(source, k, v);
+	merge: function(target){
 		for (var i = 1, l = arguments.length; i < l; i++){
 			var object = arguments[i];
-			for (var key in object) mergeOne(source, key, object[key]);
+			for (var key in object) {
+				var value = object[key];
+				switch (typeOf(value)){
+					case 'object':
+						if (typeOf(target[key]) == 'object') Object.merge(target[key], value);
+						else target[key] = Object.clone(value);
+					break;
+					case 'array': target[key] = value.clone(); break;
+					default: target[key] = value;
+				}
+			}
 		}
-		return source;
+		return target;
 	},
 
 	clone: function(object){


### PR DESCRIPTION
- Removes the undocumented special case Object.merge(target, key, value)
- Saves a typeOf check for each invokation
- No additional function calls per additional arguments
