### PR TITLE
VAR is not defined

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -30,7 +30,7 @@ this.MooTools = {
 // typeOf, instanceOf
 
 var typeOf = this.typeOf = function(item){
-	if (item == null) return 'null';
+	if (typeof item == 'undefined' || item == null) return 'null';
 	if (item.$family) return item.$family();
 
 	if (item.nodeName){
@@ -463,7 +463,7 @@ this.$clear = function(timer){
 };
 
 this.$defined = function(obj){
-	return (obj != null);
+	return (typeof obj != 'undefined');
 };
 
 this.$each = function(iterable, fn, bind){


### PR DESCRIPTION
$defined has to do with undefined variables.
Comparing a variable with null, instead of using typeof, make the browser  to return  a "VAR is not defined" error.
