### PR TITLE
Element Method: removeClass

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -514,7 +514,9 @@ Element.implement({
 	},
 
 	removeClass: function(className){
-		this.className = this.className.replace(new RegExp('\\b(' + classNames.replace(/\s+/g, "|") + '\\b)', 'g'), '').clean();
+		className.split(/\s+/).each(function(str) {
+			this.className = this.className.replace(new RegExp('(^|\\s)' + str + '(?:\\s|$)'), '$1').clean();
+		}, this);
 		return this;
 	},
 


### PR DESCRIPTION
Element.addClass allowes to add multiple classes at once (since they're just concatenated to the current classes of the element), but Element.removeClass only allows you to remove one class at once.

With the given regular expression you can use Element.removeClass('myClass1 myClass2') to remove multiple classes at once - just like addClass.
