### PR TITLE
Browser.Plugins.Flash.minorversion.

### DIFF
--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -102,7 +102,8 @@ var version = (Function.attempt(function(){
 }) || '0 r0').match(/\d+/g);
 
 Browser.Plugins.Flash = {
-	version: Number(version[0] || '0.' + version[1]) || 0,
+	version: Number(version[0]) || 0,
+	minorversion: Number(version[1]) || 0,
 	build: Number(version[2]) || 0
 };
 


### PR DESCRIPTION
After some research I'm pretty sure Adobe Flash versions are always named **majorVersion.minorVersion.build.buildRevision** - where buildRevision is totally useless but minorVersion is getting more and more interesting, especially since Flash 10.1 (which is not just a small update, instead it got a few new interesting and important features, eg. privacy mode).

So sometimes I need to know if it's Flash 10.1 and not Flash 10.0. With this small change I can get these informations. A quick run through http://browsershots.org/http://mootools.tv/flashtest/ shows that this is working in the important browsers.
