### PR TITLE
String.hyphenate bug fixed

### DIFF
--- a/Source/Types/String.js
+++ b/Source/Types/String.js
@@ -39,7 +39,7 @@ String.implement({
 	},
 
 	hyphenate: function(){
-		return this.replace(/[A-Z]/g, function(match){
+		return this.charAt(0) + this.substr(1).replace(/[A-Z]/g, function(match){
 			return ('-' + match.charAt(0).toLowerCase());
 		});
 	},


### PR DESCRIPTION
String.hyphenate bug fixed ('ILikeCookies'.hyphenate() == '-i-like-cookies' (now) instead of 'I-like-cookies' (with fix))
