### PR TITLE
[Class]+[Docs] Implements getters and setters (for developing at serverside or in modern browsers)

### DIFF
--- a/Docs/Class/Class.md
+++ b/Docs/Class/Class.md
@@ -92,7 +92,14 @@ Useful when implementing a default set of properties in multiple Classes.  The I
 	myAnimal.setName('Micia');
 	alert(myAnimal.name); // alerts 'Micia'.
 
-
+#### Getters/Setters Example
+	var Foo = new Class({
+		get bar(age){
+			return 'Only in modern browsers';
+		}
+	});
+	var foo = new Foo();
+	alert(foo.bar); // alerts 'Only in modern browsers'
 
 
 Class Method: implement {#Class:implement}

--- a/Source/Class/Class.js
+++ b/Source/Class/Class.js
@@ -16,6 +16,21 @@ provides: Class
 
 (function(){
 
+
+var implementGettersSetters = (typeof {}.__lookupGetter__ == 'function') ?
+	function (target, source) {
+		for (var key in source) {
+			var g = source.__lookupGetter__(key),
+				s = source.__lookupSetter__(key);
+			if ( g || s ) {
+				if (g) target.__defineGetter__(key, g);
+				if (s) target.__defineSetter__(key, s);
+			}
+		}
+		return target;
+	} : function (target, source) { return target; };
+	
+	
 var Class = this.Class = new Type('Class', function(params){
 	if (instanceOf(params, Function)) params = {initialize: params};
 
@@ -27,6 +42,7 @@ var Class = this.Class = new Type('Class', function(params){
 		this.$caller = this.caller = null;
 		return value;
 	}.extend(this).implement(params);
+	implementGettersSetters(newClass.prototype, params);
 
 	newClass.$constructor = Class;
 	newClass.prototype.$constructor = newClass;
@@ -108,6 +124,7 @@ Class.Mutators = {
 		Array.from(items).each(function(item){
 			var instance = new item;
 			for (var key in instance) implement.call(this, key, instance[key], true);
+			implementGettersSetters(this.prototype, instance);
 		}, this);
 	}
 };


### PR DESCRIPTION
I am  developing with server-side MooTools now and think, that setter/getter ability of v8 is great:

```
var Foo = new Class({
    get test() {
        console.log('Getter Foo.test');
        return this._test + '!!!';
    },
    set test(val) {
        console.log('Setter Foo.test');
        this._test = val * 10;
    },
});
var foo = new Foo();
foo.test  = 123; // 1230
alert(foo.test); // 1230!!!
```

But without this patch MooTools can't implements getters and setters. 
Both
    var Bar = new Class({
        Implements : [ Foo ]
    });
and
    var Bar = new Class({
        Extends : Foo
    });
will work fine and getters/setters of parent class will be implemented in child class.

this patch is ignored by browsers, which are not supported.
