### PR TITLE
Support for the attrbute modification event

### DIFF
--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -172,7 +172,7 @@ Element.Events = {
 	},
 	
 	modified: {
-		base: (Browser.ie) ? 'propertychange' : (Browser.chrome || Browser.safari) ? 'DOMSubtreeModified' : 'DOMAttrModified',
+		base: (Browser.ie && !Browser.ie9) ? 'propertychange' : (Browser.chrome || Browser.safari) ? 'DOMSubtreeModified' : 'DOMAttrModified',
 		condition: function(event){
 			return (event.target != this) ? false : true;
 		},


### PR DESCRIPTION
IE calls it propertychange, standard DOM mutation events specification calls it DOMAttrModified, we can support it as 'modified'.
