### PR TITLE
defaultChecked should not call setAttribute

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -379,7 +379,7 @@ var camels = ['defaultValue', 'accessKey', 'cellPadding', 'cellSpacing', 'colSpa
 	'rowSpan', 'tabIndex', 'useMap'
 ];
 var bools = ['compact', 'nowrap', 'ismap', 'declare', 'noshade', 'checked', 'disabled', 'readOnly', 'multiple', 'selected',
-	'noresize', 'defer'
+	'noresize', 'defer', 'defaultChecked'
 ];
  var attributes = {
 	'html': 'innerHTML',


### PR DESCRIPTION
Document.newElement sets props.defaultChecked to false if you pass checked: false. This then calls setAttribute('defaultChecked', 'false'), which will keep the checkbox checked in IE.

This makes it behave the same as FF / Chrome / Safari.
