### PR TITLE
Added control,alt and shift to Event.Keys

### DIFF
--- a/Source/Types/Event.js
+++ b/Source/Types/Event.js
@@ -104,7 +104,7 @@ Event.Keys = {
 	'space': 32,
 	'backspace': 8,
 	'tab': 9,
-	'delete': 46
+	'delete': 46,
     'shift' : 16, 
     'control' : 17,
     'alt' : 18,    


### PR DESCRIPTION
fix suggestion to this ticket:
https://mootools.lighthouseapp.com/projects/2706-mootools/tickets/1109-eventkey-doesnt-wrok-proerly
