### PR TITLE
use textContent before innerText

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -387,7 +387,7 @@ var bools = ['compact', 'nowrap', 'ismap', 'declare', 'noshade', 'checked', 'dis
 	'for': 'htmlFor',
 	'text': (function(){
 		var temp = document.createElement('div');
-		return (temp.innerText == null) ? 'textContent' : 'innerText';
+		return (temp.textContent == null) ? 'innerText' : 'textContent';
 	})()
 };
 var readOnly = ['type'];


### PR DESCRIPTION
Since textContent is the standard, why not try to use that first. If it doesn't exist, then fall back to other accessors, like innerText.

Reason: Chrome implements both, which works fine until you try to use XML elements. XML Elements only have textContent set, not innerText.
