### PR TITLE
Change event fix for IE

### DIFF
--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -195,8 +195,7 @@ Element.Events = {
 							break;
 						}
 					} 
-				};
-					
+				};	
 				this.store('change:events', events).addEvents(events);
 			}
 		},


### PR DESCRIPTION
The change event now works in IE the way it does in all other browsers. This implementation is shorter, more concise, and has one less temp event.
