### PR TITLE
Add Object.inject method

### DIFF
--- a/Source/Types/Object.js
+++ b/Source/Types/Object.js
@@ -87,6 +87,24 @@ Object.extend({
 		return Object.keyOf(object, value) != null;
 	},
 
+	inject: function(object, newKey, newVal, fn, bind){
+		var prevKey=null, prevVal=null, inserted=false, newobject={};
+		for(var currKey in object){
+			if (object.hasOwnProperty(currKey)){
+				var currVal = object[currKey];
+				if( !inserted && fn.call(bind, prevKey, prevVal, currKey, currVal) ){
+					newobject[newKey] = newVal;
+					inserted=true;
+				}
+				newobject[currKey] = currVal;
+				prevKey = currKey;
+				prevVal = object[currKey];
+			} 
+		}
+		if(!inserted) newobject[newKey] = newVal;
+		return newobject;
+	},
+
 	toQueryString: function(object, base){
 		var queryString = [];
 


### PR DESCRIPTION
I've added an Object.inject function to inject a key/value into an object at a specific location.  Not sure of the approval process but thought I would share:

Object.inject(object, newKey, newVal, fn, bind)
Inserts the item into the object where the fn parameter returns true
- object = the object to work on
- newKey = the new key to insert
- newVal = new value to insert
- fn = a function called per iteration, return true to insert at this position
  function (previousKey, previousValue, nextKey, nextValue){ }
- bind = the object to use as 'this' in the function.

So given such object:

```
var tmp1 = { 
    Tom: 'first', 
    Jane: 'second', 
    Sally: 'third', 
    Bill: 'forth', 
    Lydia: 'fifth', 
    Carl: 'sixth', 
    Stan: 'seventh', 
    Earl: 'eighth', 
    Paul: 'ninth', 
    Tray: 'tenth' 
};
```

I can insert the key "Trent": "NEW ITEM" at the position before key item "Earl":

```
var tmp2 = Object.inject(tmp1, 'Trent', 'NEW ITEM', function(ak, av, bk, bv){ 
        return (bk=='Earl'); 
    });
```

This is particularly useful when we have objects which were sorted in a particular order and must add values in the correct positions.
