### PR TITLE
Continues Fx

### DIFF
--- a/Source/Fx/Fx.js
+++ b/Source/Fx/Fx.js
@@ -46,7 +46,7 @@ var Fx = this.Fx = new Class({
 	},
 
 	step: function(now){
-		if (this.duration == 0 || this.options.frameSkip){
+		if (this.duration == Infinity || this.options.frameSkip){
 			var diff = (this.time != null) ? (now - this.time) : 0, frames = diff / this.frameInterval;
 			this.time = now;
 			if (!this.startTime) this.startTime = now;
@@ -55,10 +55,10 @@ var Fx = this.Fx = new Class({
 			this.frame++;
 		}
 
-		if (this.duration == 0 || this.frame < this.frames){
-			this.set(this.duration
-				? this.compute(this.from, this.to, this.transition(this.frame / this.frames))
-				: diff
+		if (this.frame < this.frames){
+			this.set(this.duration == Infinity
+				? diff
+				: this.compute(this.from, this.to, this.transition(this.frame / this.frames))
 			);
 		} else {
 			this.frame = this.frames;
@@ -95,7 +95,7 @@ var Fx = this.Fx = new Class({
 		var frames = this.options.frames,
 			fps = this.options.fps,
 			duration = this.options.duration;
-		this.duration = duration in Fx.Durations ? Fx.Durations[duration] : (duration || 0).toInt();
+		this.duration = Fx.Durations[duration] || (duration == Infinity ? Infinity : (duration).toInt());
 		this.frameInterval = 1000 / fps;
 		this.frames = frames || Math.round(this.duration / this.frameInterval);
 		this.fireEvent('start', this.subject);
@@ -107,10 +107,12 @@ var Fx = this.Fx = new Class({
 		if (this.isRunning()){
 			this.time = null;
 			pullInstance.call(this, this.options.fps);
-			if (this.frames == this.frame || this.duration == 0){
+			if (this.frames == this.frame || this.duration == Infinity){
 				this.fireEvent('complete', this.subject);
 				if (!this.callChain()) this.fireEvent('chainComplete', this.subject);
-			} else {
+
+			}
+			if (this.frames != this.frame){
 				this.fireEvent('stop', this.subject);
 			}
 		}
@@ -151,7 +153,7 @@ Fx.compute = function(from, to, delta){
 	return (to - from) * delta + from;
 };
 
-Fx.Durations = {'short': 250, 'normal': 500, 'long': 1000, 'continues': 0};
+Fx.Durations = {'short': 250, 'normal': 500, 'long': 1000, 'infinite': Infinity};
 
 // global timers
 


### PR DESCRIPTION
With this change you can set the duration to `0` and it will run until `stop` has been called.

This is especially useful when you'd like to make some nice Fx.Gravity where you don't know the duration in advance, or some continues sprite animation.

Now the step method doesn't have to be overwritten or set this.frames and this.frame to 1 or other ugly things to make it run and extend Fx for this.

The reason why not just setInterval is used is because of the global times, the stop/start/cancel/pause/resume methods and stuff like that.

Demo of Fx.Gravity: http://jsfiddle.net/GZGFu/7/
