### PR TITLE
Fix get position

### DIFF
--- a/Source/Element/Element.Dimensions.js
+++ b/Source/Element/Element.Dimensions.js
@@ -137,7 +137,6 @@ Element.implement({
 	},
 
 	getPosition: function(relative){
-		if (isBody(this)) return {x: 0, y: 0};
 		var offset = this.getOffsets(),
 			scroll = this.getScrolls();
 		var position = {


### PR DESCRIPTION
When the body is styled, the deleted line would cause a bad result.
see here:
http://jsfiddle.net/wgGYu/

result should log x:0, but logs the distance from the html element. 
