### PR TITLE
IE and !mobile specific packager blocks (Part 1)

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -29,8 +29,13 @@ var Element = function(tag, props){
 		var attributes = parsed.attributes;
 		if (attributes) for (var i = 0, l = attributes.length; i < l; i++){
 			var attr = attributes[i];
-			if (attr.value != null && attr.operator == '=' && props[attr.key] == null)
-				props[attr.key] = attr.value;
+			if (props[attr.key] == null){
+				if (attr.value != null && attr.operator == '='){
+					props[attr.key] = attr.value;
+				} else if (!attr.value && !attr.operator){
+					props[attr.key] = true;
+				}
+			}
 		}
 
 		if (parsed.classList && props['class'] == null) props['class'] = parsed.classList.join(' ');


### PR DESCRIPTION
I am working on wrapping very specific feature detection with packager blocks. The aim of this is to be able to create a smaller build, ie. for mobile devices or webkit only web apps.

I have created a test build with

```
packager build Core/Class.Extras Core/DOMReady Core/Element.Style Core/Request.JSON -blocks 1.2compat ltIE8 ltIE9 \!mobile > mootools-core-mobile.js
```

which works in Chrome. Of course I need to do more testing in the actual IE versions.

I am also not sure about the <!mobile> block. It could also be named <!webkit> but that would exclude Gecko based browsers. I used it for example for `Function.prototype.bind`. Arguably we could also change this specific block to <ltIE9>. I think !mobile sums this up best, because on mobile this method can be assumed to be available. Does anyone have a better idea for this?

The biggest component is Slick.Finder and I am unsure on how to provide an optimized build, there are several options:
- Packager headers in Slick, mostly for the feature detection parts (probably won't help a lot)
- Create a Slick.Finder.Light version that provides the most basic features, no feature detection for older browsers
- …

@kamicane @subtleGradient @fabiomcosta @timwienk @arian
