### PR TITLE
Allow a selector to be used as the "where" argument for inject and grab

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -557,12 +557,12 @@ Element.implement({
 	},
 
 	grab: function(el, where){
-		inserters[where || 'bottom'](document.id(el, true), this);
+		inserters[where || 'bottom'](document.id(el, true) || document.getElement(el), this);
 		return this;
 	},
 
 	inject: function(el, where){
-		inserters[where || 'bottom'](this, document.id(el, true));
+		inserters[where || 'bottom'](this, document.id(el, true) || document.getElement(el));
 		return this;
 	},
 


### PR DESCRIPTION
Selectors are now able to be passed to specify a more granular place for injection of an element.
