### PR TITLE
Alllow a selector to be used in addition to ID reference strings in element additions to the DOM

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -557,12 +557,12 @@ Element.implement({
 	},
 
 	grab: function(el, where){
-		inserters[where || 'bottom'](document.id(el, true), this);
+		inserters[where || 'bottom'](document.id(el, true) || document.getElement(el), this);
 		return this;
 	},
 
 	inject: function(el, where){
-		inserters[where || 'bottom'](this, document.id(el, true));
+		inserters[where || 'bottom'](this, document.id(el, true) || document.getElement(el));
 		return this;
 	},
 


### PR DESCRIPTION
Removed an errantly included console.log and changed to document.getElement vs old $$ to appease w00fz ;)

Conflicts:

```
Source/Element/Element.js
```
