### PR TITLE
Whitespace removed in See Also key in JSON.js header

### DIFF
--- a/Source/Utilities/JSON.js
+++ b/Source/Utilities/JSON.js
@@ -7,7 +7,7 @@ description: JSON encoder and decoder.
 
 license: MIT-style license.
 
-See Also: <http://www.json.org/>
+SeeAlso: <http://www.json.org/>
 
 requires: [Array, String, Number, Function]
 


### PR DESCRIPTION
Hi

Here's the yaml header of JSON.js :
## /*

name: JSON

description: JSON encoder and decoder.

license: MIT-style license.

See Also: http://www.json.org/

requires: [Array, String, Number, Function]

provides: JSON

...
*/
The line starting with 'See Also' makes the node.js yaml parser failed when extracting info to use with packager. (This component is required by Request.JSON for example)
I'm not an expert in yaml syntax, but I think keys may not contain any white space to be considered valid. 
