### PR TITLE
Creating a "this.Document" variable interferes with some versions of Java

### DIFF
--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -150,7 +150,8 @@ Window.mirror(function(name, method){
 	window[name] = method;
 });
 
-this.Document = document.$constructor = new Type('Document', function(){});
+// Creating a "Document" variable interferes with some versions of Java
+// this.Document = document.$constructor = new Type('Document', function(){});
 
 document.$family = Function.from('document').hide();
 


### PR DESCRIPTION
Creating a "this.Document" variable interferes with some versions of Java. So far it breaks on the following versions: 
- JRE 6.0 Update 7
- JRE 6.0 Update 6
- JRE 6.0 Update 5
- JRE 6.0 Update 4
  [Due to time constraints JRE 6.0 to JRE 6.0 Update 3 were not tested]
- JRE 5.0 Update 22
  [Due to time constraints JRE 5.0 Update 16 to JRE 5.0 Update 21 were not tested]
- JRE 5.0 Update 15
  [Due to time constraints JRE 5.0 Update 1 to JRE 5.0 Update 14 were not tested]
- JRE 5.0
  Simply removing this line:
  `this.Document = document.$constructor = new Type('Document', function(){});`

Or changing the variable name to something other than "Document" e.g. "Document2" fixes the problem. However this would require further modifications throughout the code to reflect this change.

An example of this can be demonstrated on jsFiddle where the "Result" window only shows a white box when one of the versions of Java listed above is installed:
http://jsfiddle.net/ZeZvp/

Changing to Mootools 1.2.5 fixes the problem as the variable does not exist in that code base, allowing the applet to load.

Does anyone know whether this can be fixed within JavaScript or is this more a problem with Java?

Thanks
