### PR TITLE
Added note about CSS selector availability for Morph calls.

### DIFF
--- a/Docs/Fx/Fx.Morph.md
+++ b/Docs/Fx/Fx.Morph.md
@@ -128,6 +128,7 @@ Executes a transition for any number of CSS properties in tandem.
 
 - If a string is passed as the CSS selector, the selector must be identical to the one within the CSS.
 - Multiple selectors (with commas) are not supported.
+- @import'ed CSS rules will not be available for Morph calls. All CSS selectors must be present in CSS directly loaded into the page.
 
 
 Object: Element.Properties {#Element-Properties}


### PR DESCRIPTION
Ensure the docs mention that @import'ed CSS selectors are not available for Morph.
