### PR TITLE
Fixes #2004 - Fix Function:bind when the resulting function is used as co

### DIFF
--- a/Source/Types/Function.js
+++ b/Source/Types/Function.js
@@ -38,15 +38,23 @@ Function.implement({
 	},
 
 	/*<!ES5>*/
-	bind: function(bind){
+	bind: function(that){
 		var self = this,
-			args = (arguments.length > 1) ? Array.slice(arguments, 1) : null;
-		
-		return function(){
-			if (!args && !arguments.length) return self.call(bind);
-			if (args && arguments.length) return self.apply(bind, args.concat(Array.from(arguments)));
-			return self.apply(bind, args || arguments);
+			args = arguments.length > 1 ? Array.slice(arguments, 1) : null,
+			F = function(){};
+
+		var bound = function(){
+			var context = that, length = arguments.length;
+			if (this instanceof bound){
+				F.prototype = self.prototype;
+				context = new F;
+			}
+			var result = (!args && !length)
+				? self.call(context)
+				: self.apply(context, args && length ? args.concat(Array.slice(arguments)) : args || arguments);
+			return context == that ? result : context;
 		};
+		return bound;
 	},
 	/*</!ES5>*/
 


### PR DESCRIPTION
Fixes #2004 - Fix Function:bind when the resulting function is used as constructor

See https://gist.github.com/1120592
