### PR TITLE
Reset Object.create to null if previously not present.

### DIFF
--- a/Source/Types/Function.js
+++ b/Source/Types/Function.js
@@ -113,6 +113,8 @@ Function.implement({
 
 });
 
+if (Object.create == Function.prototype.create) Object.create = null;
+
 var $try = Function.attempt;
 
 //</1.2compat>

--- a/Source/Types/Object.js
+++ b/Source/Types/Object.js
@@ -16,14 +16,9 @@ provides: [Object, Hash]
 
 (function(){
 
-var hasOwnProperty = Object.prototype.hasOwnProperty, F = function(){};
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 Object.extend({
-	
-	create: function(object){
-		F.prototype = object;
-		return new F;
-	},
 
 	subset: function(object, keys){
 		var results = {};


### PR DESCRIPTION
`Function.implement('create', function(){})` will succeed if `Object.create` is not present. This is a bug for libraries and users that check for `Object.create` presence and try to use it.
