### PR TITLE
Optimize Element.Properties.html.set a bit by not using `arguments` or `A

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -874,8 +874,8 @@ Element.Properties.html = (function(){
 	translations.thead = translations.tfoot = translations.tbody;
 
 	var html = {
-		set: function(){
-			var html = Array.flatten(arguments).join('');
+		set: function(html){
+			if (typeof html != 'string') html = html.join('');
 			var wrap = (!tableTest && translations[this.get('tag')]);
 			if (wrap){
 				var first = wrapper;


### PR DESCRIPTION
Optimize Element.Properties.html.set a bit by not using `arguments` or `Array:flatten`.

Using strings is the only documented way anyway. 
