### PR TITLE
Adding attributes for html5 video/audio elements

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -524,7 +524,8 @@ Object.forEach(properties, function(real, key){
 var bools = [
 	'compact', 'nowrap', 'ismap', 'declare', 'noshade', 'checked',
 	'disabled', 'readOnly', 'multiple', 'selected', 'noresize',
-	'defer', 'defaultChecked', 'autofocus'
+	'defer', 'defaultChecked', 'autofocus', 'controls', 'autoplay',
+	'loop'
 ];
 
 var booleans = {};


### PR DESCRIPTION
I've added loop, control, and autoplay into bools so setProperty/getProperty will return boolean values.

Specs here: https://github.com/GCheung55/mootools-core-specs/commit/692d09464022e554ec81c99f9dd93c2bf9719c33
