### PR TITLE
Numbers are now allowed too for Element.Properties.html

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -888,7 +888,8 @@ Element.Properties.html = (function(){
 
 	var html = {
 		set: function(html){
-			if (typeof html != 'string') html = html.join('');
+			if (typeOf(html) == 'array') html = html.join('');
+
 			var wrap = (!tableTest && translations[this.get('tag')]);
 			/*<ltIE9>*/
 			if (!wrap && !HTML5Test) wrap = [0, '', ''];


### PR DESCRIPTION
Using `element.set('html', 1);` didn't work anymore when I removed that `Array.flatten()`.

Also added specs for this now: https://github.com/arian/mootools-core-specs/compare/element-properties-html
