### PR TITLE
Minor Tweak to TypeOf

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -31,7 +31,7 @@ this.MooTools = {
 
 var typeOf = this.typeOf = function(item){
 	if (item == null) return 'null';
-	if (item.$family) return item.$family();
+	if (item.$family != null) return item.$family();
 
 	if (item.nodeName){
 		if (item.nodeType == 1) return 'element';


### PR DESCRIPTION
Long explanation: HtmlUnit (a headless browser implementation for unit testing) was barfing on typeOf whenever you called it with a string. That's because it evaluated "".$family as "falsy" despite being defined. An explicit check here solved the problem and now _most_ of the unit tests for Core pass (not the ones that are fairly browser specific, like element measurements and whatnot).
