### PR TITLE
Fix typo of "Safe"

### DIFF
--- a/Docs/Element/Element.md
+++ b/Docs/Element/Element.md
@@ -65,7 +65,7 @@ However it is not recommended to use more frameworks, the $ variable can be set 
 
 
 ### See Also:
- - MooTools Blogpost: [The Dollar Save Mode][]
+ - MooTools Blogpost: [The Dollar Safe Mode][]
 
 
 Function: $$ {#Window:dollars}


### PR DESCRIPTION
The blog post's title is "The Dollar Safe Mode", not "The Dollar Save Mode."
