### PR TITLE
Fixes #2116 - Fixes broken Chain for Element.fade

### DIFF
--- a/Source/Fx/Fx.Tween.js
+++ b/Source/Fx/Fx.Tween.js
@@ -89,6 +89,7 @@ Element.implement({
 		if (method == 'set' || to != 0) this.setStyle('visibility', to == 0 ? 'hidden' : 'visible');
 		else fade.chain(function(){
 			this.element.setStyle('visibility', 'hidden');
+			this.callChain();
 		});
 		return this;
 	},


### PR DESCRIPTION
Using callChain to call the other chained functions.
