### PR TITLE
fix for any propertychange firing onChange in ie7/8 on checkboxes AND radios

### DIFF
--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -175,7 +175,7 @@ if (!window.addEventListener){
 			return (this.get('tag') == 'input' && (type == 'radio' || type == 'checkbox')) ? 'propertychange' : 'change'
 		},
 		condition: function(event){
-			return !!(this.type != 'radio' || this.checked);
+			return !!(this.type != 'radio' || this.checked && event.event.propertyName == 'checked');
 		}
 	}
 }


### PR DESCRIPTION
see https://github.com/mootools/mootools-core/issues/2170, updated to also support checkboxes. testcase: http://jsfiddle.net/5CvBb/12/
