### PR TITLE
Fixes 2169.

### DIFF
--- a/Source/Types/Array.js
+++ b/Source/Types/Array.js
@@ -26,8 +26,9 @@ Array.implement({
 
 	filter: function(fn, bind){
 		var results = [];
-		for (var i = 0, l = this.length >>> 0; i < l; i++){
-			if ((i in this) && fn.call(bind, this[i], i, this)) results.push(this[i]);
+		for (var value, i = 0, l = this.length >>> 0; i < l; i++) if (i in this){
+			value = this[i];
+			if (fn.call(bind, value, i, this)) results.push(value);
 		}
 		return results;
 	},

--- a/Specs/1.4base/Types/Array.js
+++ b/Specs/1.4base/Types/Array.js
@@ -26,4 +26,20 @@ describe('Array', function(){
 		expect([].some.call(object, fn)).toBe(false);
 	});
 
+	describe('Array.filter', function(){
+
+		it('should return the original item, and not any mutations.', function(){
+
+			var result = [0, 1, 2].filter(function(num, i, array){
+				if (num == 1){
+					array[i] = 'mutation';
+					return true;
+				}
+			});
+
+			expect(result[0]).toEqual(1);
+		});
+
+	});
+
 });


### PR DESCRIPTION
As per spec, `Array.filter` should return the filtered items, and not
andany possible mutation that might have occurred in the callback. See
referenced issue for more information.

Added coverage for case.

PASSED: IE6-9; FF3-5, 8, 11; Chrome latest; Safari 5; Opera 11
