### PR TITLE
Fix #2184: IE9 on Windows Server throws exception; can't continue

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -546,10 +546,18 @@ Array.forEach(bools, function(bool){
 	var lower = bool.toLowerCase();
 	booleans[lower] = bool;
 	propertySetters[lower] = function(node, value){
-		node[bool] = !!value;
+		try {
+			node[bool] = !!value;
+		} catch (ex) {
+			// Nothing here.
+		}
 	};
 	propertyGetters[lower] = function(node){
-		return !!node[bool];
+		try {
+			return !!node[bool];
+		} catch (ex) {
+			return false;
+		}
 	};
 });
 

--- a/Source/Slick/Slick.Finder.js
+++ b/Source/Slick/Slick.Finder.js
@@ -214,6 +214,7 @@ local.setDocument = function(document){
 		// IE8 does not have .contains on document.
 		return context === node || ((context === document) ? document.documentElement : context).contains(node);
 	} : (root && root.compareDocumentPosition) ? function(context, node){
+		if (node === null) return false; /* Fix for Firefox 5 throwing NS_ERROR_ILLEGAL_VALUE when calling compareDocumentPosition(null) */
 		return context === node || !!(context.compareDocumentPosition(node) & 16);
 	} : function(context, node){
 		if (node) do {


### PR DESCRIPTION
This fixes an issue in IE9 on Windows machines that lack certain media codecs.
