### PR TITLE
Fixes #2182 - Element.erase('html') should set the innerHTML to an empty string

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -920,6 +920,7 @@ Element.Properties.html = (function(){
 	var html = {
 		set: function(html){
 			if (typeOf(html) == 'array') html = html.join('');
+			else if (!html) html = '';
 
 			var wrap = (!tableTest && translations[this.get('tag')]);
 			/*<ltIE9>*/

--- a/Specs/1.4client/Element/Element.js
+++ b/Specs/1.4client/Element/Element.js
@@ -162,6 +162,14 @@ describe('Element', function(){
 
 	});
 
+	describe("Element.erase('html')", function(){
+
+		it('should empty the html inside an element', function(){
+			expect(new Element('div', {html: '<p>foo bar</p>'}).erase('html').innerHTML).toEqual('');
+		});
+
+	});
+
 	describe('Element.clone', function(){
 
 		it('should not crash IE for multiple clones', function(){


### PR DESCRIPTION
Element.properties.html.erase was aliased to Element.properties.html.set, but when calling it without any arguments this resulted in .set(undefined).

See #2182
