### PR TITLE
Replaced w3schools event attributes link with MDN DOM reference

### DIFF
--- a/Docs/Element/Element.Event.md
+++ b/Docs/Element/Element.Event.md
@@ -45,7 +45,7 @@ Attaches an event listener to a DOM element.
 
 ### See Also:
 
-- [w3schools Event Attributes](http://www.w3schools.com/html/html_eventattributes.asp)
+- [MDN DOM Event Reference](https://developer.mozilla.org/en/DOM/DOM_event_reference)
 
 
 


### PR DESCRIPTION
Unlike MDN, w3schools isn't up to date with the industry standards or best practices so it is not as reliable or informative.
