### PR TITLE
Fixes #2163.

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -262,7 +262,11 @@ Document.implement({
 			element: function(el, nocash){
 				Slick.uidOf(el);
 				if (!nocash && !el.$family && !(/^(?:object|embed)$/i).test(el.tagName)){
-					el._fireEvent = el.fireEvent;
+					var fireEvent = el.fireEvent;
+					// wrapping needed in IE7, or else crash
+					el._fireEvent = function(type, event){
+						return fireEvent(type, event);
+					};
 					Object.append(el, Element.Prototype);
 				}
 				return el;


### PR DESCRIPTION
IE7 seems to have issues with assigning native functions as properties.
Fix is to wrap the native function with an anon. func..

PASSED: IE6-9; FFx 3-5, 8, 10; Chrome latest; Safari 5; Opera 11
