### PR TITLE
Fixes #2164.

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -568,7 +568,7 @@ Object.append(propertySetters, {
 	},
 
 	'value': function(node, value){
-		node.value = value || '';
+		node.value = (value != null) ? value : '';
 	}
 
 });

--- a/Specs/1.4client/Element/Element.js
+++ b/Specs/1.4client/Element/Element.js
@@ -37,6 +37,11 @@ describe('Element', function(){
 				expect(new Element('input', {value: value}).get('value')).toEqual('');
 			});
 
+			it('should set a falsey value and not an empty string', function(){
+				expect(new Element('input', {value: false}).get('value')).toEqual('false');
+				expect(new Element('input', {value: 0}).get('value')).toEqual('0');
+			});
+
 		});
 
 		describe('type', function(){


### PR DESCRIPTION
Changed value property setter was too strict with defaulting to an empty
string. Now Element.set('value') for falsey values depends on toString
of that object for setting the right value.

PASSED: IE6-9; FFx 3-5, 8; 10; Safari 5; Opera 11; Chrome latest
