### PR TITLE
Fix 2170 ie element event change propertychange

### DIFF
--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -175,7 +175,7 @@ if (!window.addEventListener){
 			return (this.get('tag') == 'input' && (type == 'radio' || type == 'checkbox')) ? 'propertychange' : 'change'
 		},
 		condition: function(event){
-			return event.type == 'change' || !!this.checked && event.type == 'propertychange' && event.event.propertyName == 'checked';
+			return this.type != 'radio' || (event.event.propertyName == 'checked' && this.checked);
 		}
 	}
 }

--- a/Specs/1.4client/Element/Element.Event.js
+++ b/Specs/1.4client/Element/Element.Event.js
@@ -96,7 +96,16 @@ describe('Element.Event.change', function(){
 		input.removeClass('someClass');
 		expect(callback).not.toHaveBeenCalled();
 
-		input.destroy();
+		var text = new Element('input', {
+			'type': 'text',
+			'class': 'otherClass',
+			'value': 'text value'
+		}).addEvent('change', callback).inject(document.body);
+
+		text.removeClass('otherClass');
+		expect(callback).not.toHaveBeenCalled();
+
+		[input, text].invoke('destroy');
 	});
 
 });


### PR DESCRIPTION
Adds fix and spec coverage for Element.Event.change. Specifically propertychange event in IE that was called too many times.

See #2170 and #2172.
