### PR TITLE
Fixes #2247.

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -636,8 +636,9 @@ Element.implement({
 			var attr = this.getAttributeNode(name), attributeWhiteList = this.retrieve('$attributeWhiteList', {});
 			if (!attr) return null;
 			if (attr.expando && !attributeWhiteList[name]){
-				var outer = this.outerHTML, i = outer.indexOf(name), l = outer.indexOf('><');
-				if ((i < 0) || (i > l && l > 0)) return null;
+				var outer = this.outerHTML;
+				// segment by the opening tag and find mention of attribute name
+				if (outer.substr(0, outer.search(/\/?['"]?>(?![^<]*<['"])/)).indexOf(name) < 0) return null;
 				attributeWhiteList[name] = true;
 			}
 		}

--- a/Specs/1.4client/Element/Element.js
+++ b/Specs/1.4client/Element/Element.js
@@ -41,7 +41,17 @@ describe('Element', function(){
 
 			div = new Element('div', {html: '<a data-custom="singular" href="#">href</a>'}).getFirst();
 			expect(div.get('data-custom')).toEqual('singular');
+
+			div = new Element('div', {html: '<div class="><" data-custom="evil attribute values"></div>'}).getFirst();
+			expect(div.get('data-custom')).toEqual('evil attribute values');
+
+			div = new Element('div', {html: '<div class="> . <" data-custom="aggrevated evil attribute values"></div>'}).getFirst();
+			expect(div.get('data-custom')).toEqual('aggrevated evil attribute values');
+
+			div = new Element('div', {html: '<a href="#"> data-custom="singular"</a>'}).getFirst();
+			expect(div.get('data-custom')).toEqual(null);
 		});
+
 
 	});
 


### PR DESCRIPTION
This fixes a nasty regression that custom attributes set by HTML text
(e.g. innerHTML) would previously be considered `expando` and therefore
thought to have been considered a fake attribute. Therefore, we didn't
return the value.

This fix relies now on outerHTML to check for the existence of the
attribute. Keep in mind this also fixes the previous bug of returning
custom functions since any new `el.attribute =` are not shown in
outerHTML.

PASSED: IE6-9.
