### PR TITLE
Fix #2251 prototype enumeration

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -235,8 +235,6 @@ var force = function(name, object, methods){
 	var isType = (object != Object),
 		prototype = object.prototype;
 
-	object.$methods = methods;
-
 	if (isType) object = new Type(name, object);
 
 	for (var i = 0, l = methods.length; i < l; i++){
@@ -246,6 +244,16 @@ var force = function(name, object, methods){
 
 		if (generic) generic.protect();
 		if (isType && proto) object.implement(key, proto.protect());
+	}
+
+	if (isType){
+		var methodsEnumerable = prototype.propertyIsEnumerable(methods[0]);
+		object.forEachMethod = function(fn){
+			if (!methodsEnumerable) for (var i = 0, l = methods.length; i < l; i++){
+				fn.call(prototype, prototype[methods[i]], methods[i]);
+			}
+			for (var key in prototype) fn.call(prototype, prototype[key], key)
+		};
 	}
 
 	return force;

--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -194,11 +194,9 @@ if (object[1] == 1) Elements.implement('splice', function(){
 	return result;
 }.protect());
 
-Array.$methods.each(function(method){
-	Elements.implement(method, Array.prototype[method]);
+Array.forEachMethod(function(method, name){
+	Elements.implement(name, method);
 });
-
-Elements.implement(Array.prototype);
 
 Array.mirror(Elements);
 


### PR DESCRIPTION
Fix #2251 

See commit messages for more info.

Basically what happened is that the native methods were reassigned to make them enumerable with for-in loops.
As #2251 described this made optimizations by Chrome impossible, yielding in a significant performance hit.

The solution creates a `object.forEachMethod(fn)` function that can iterate over each method. The only time this is really necessary is in Element.js when copying array methods onto Elements.
