### PR TITLE
SVGAnimatedString causes Slick error

### DIFF
--- a/Source/Slick/Slick.Finder.js
+++ b/Source/Slick/Slick.Finder.js
@@ -860,7 +860,9 @@ for (var p in pseudos) local['pseudo:' + p] = pseudos[p];
 var attributeGetters = local.attributeGetters = {
 
 	'class': function(){
-		return this.getAttribute('class') || typeOf(this.className) == 'string' ? this.className : null;
+		var className = this.className;
+		if (className && className.baseVal !== undefined) className = className.baseVal;
+		return className || this.getAttribute('class');
 	},
 
 	'for': function(){


### PR DESCRIPTION
When i have an animated svg embeded in the page, the '*=' attribute matching crashes because the value className on SVGSVGElement is not a string but SVGAnimatedString

I am not sure this is the best fix, but it works, this might have implications else where.

I considered just skipping all svg's but is seems more helpful to be able to find them and be able to script them.

i found this error matching [class*="tipOptions:"] on the document.  
