### PR TITLE
Fixes #2236.

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -89,6 +89,7 @@ Element.implement({
 		if (property == 'opacity') return getOpacity(this);
 		property = (property == 'float' ? floatName : property).camelCase();
 		var result = this.style[property];
+		if (property == 'clip') result = result.replace(/,\s*/g, ' ');
 		if (!result || property == 'zIndex'){
 			result = [];
 			for (var style in Element.ShortStyles){

--- a/Specs/1.4client/Fx/Fx.Tween.js
+++ b/Specs/1.4client/Fx/Fx.Tween.js
@@ -59,4 +59,36 @@ describe('Fx.Tween', function(){
 
 	});
 
+	describe('Element.tween("clip")', function(){
+
+		it('should animate the clip', function(){
+			var element = new Element('div', {
+				text: Array(5).join('Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod '),
+				styles: {
+					width: 200,
+					height: 100,
+					position: 'absolute',
+					clip: 'rect(0px, 0px, 200px, 0px)'
+				}
+			});
+			var spy = spyOn(element, 'setStyle').andCallThrough();
+
+			element.tween('clip', 'rect(0px, 100px, 200px, 0px)');
+
+			this.clock.tick(10000);
+
+			expect(spy).toHaveBeenCalledWith('clip', ['rect(0px,', 100, 200, 0]);
+
+			spy.reset();
+
+			element.tween('clip', 'rect(0px 50px 200px 0px)');
+
+			this.clock.tick(10000);
+
+			expect(spy).toHaveBeenCalledWith('clip', ['rect(0px', 50, 200, 0]);
+
+		})
+
+	});
+
 });


### PR DESCRIPTION
Turns out this wasn't a Fx.CSS.parser issue but more of a
Element.getStyle needed to clean the value from rect(a, b, c, d) to our
preferred value of rect(a b c d).

This solves IE8 issue of returning rect(a,b,c,d) and non-webkit
returning rect(a, b, c, d). Element.setStyle still accepts rect(a b c d)
or rect(a, b, c, d).

PASSED: IE6-9; FFx 3-5, 8, 10; Chrome latest; Safari 5; Opera 11
