### PR TITLE
Remove opacity filter in IE if the opacity is 1.

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -45,7 +45,7 @@ var setOpacity = (hasOpacity ? function(element, opacity){
 } : (hasFilter ? function(element, opacity){
 	var style = element.style;
 	if (!element.currentStyle || !element.currentStyle.hasLayout) style.zoom = 1;
-	if (opacity == null) opacity = '';
+	if (opacity == null || opacity == 1) opacity = '';
 	else opacity = 'alpha(opacity=' + (opacity * 100).limit(0, 100).round() + ')';
 	var filter = style.filter || element.getComputedStyle('filter') || '';
 	style.filter = reAlpha.test(filter) ? filter.replace(reAlpha, opacity) : filter + opacity;

--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -12,7 +12,7 @@ describe('Element.Style', function(){
 
 		beforeEach(function(){
 			var className = String.uniqueID();
-			var style = this.style = document.createElement('style');
+			var style = this.style = $(document.createElement('style'));
 			style.type = 'text/css';
 			var definition = [
 				'.' + className + '{',
@@ -44,10 +44,14 @@ describe('Element.Style', function(){
 		});
 
 		it('should set/overwrite the opacity', function(){
-			this.element.setStyle('opacity', 1);
-			expect(this.element.getStyle('opacity')).toEqual(1);
-			this.element.setStyle('opacity', null);
-			expect(this.element.getStyle('opacity')).toEqual(0.5);
+			// this test is disabled in IE, because of the ugly aliasing with
+			// opacity we have to remove the filter in oldIE
+			if (document.html.style.filter == null || window.opera || Syn.browser.gecko){
+				this.element.setStyle('opacity', 1);
+				expect(this.element.getStyle('opacity')).toEqual(1);
+				this.element.setStyle('opacity', null);
+				expect(this.element.getStyle('opacity')).toEqual(0.5);
+			}
 		});
 
 		it('should remove the style by setting it to `null`', function(){


### PR DESCRIPTION
regression due b3e80ee15b to pass the added spec (which is disabled in this pr).

```
<arian> I did it, because it can have a: filter: alpha(opacity=50) in the CSS
<arian> so when you remove it with 1, it will be 0.5
<arian> was my reasoning..
<arian> but maybe remove it on 1 is better because it's pretty ugly when you fade from 0 to 1
```
