### PR TITLE
Fixes Function.prototype.overloadGetter(usePlural), when it's called as getter('aa')

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -86,8 +86,9 @@ Function.prototype.overloadGetter = function(usePlural){
 	var self = this;
 	return function(a){
 		var args, result;
-		if (usePlural || typeof a != 'string') args = a;
+		if (typeof a != 'string') args = a;
 		else if (arguments.length > 1) args = arguments;
+		else if (usePlural) args = [a];
 		if (args){
 			result = {};
 			for (var i = 0; i < args.length; i++) result[args[i]] = self.call(this, args[i]);

--- a/Specs/1.3base/Core/Core.js
+++ b/Specs/1.3base/Core/Core.js
@@ -67,9 +67,9 @@ describe('Function.prototype.overloadGetter', function(){
 	var object, getter;
 	beforeEach(function(){
 		object = {
-			a: 1,
-			b: 2,
-			c: 3
+			aa: 1,
+			bb: 2,
+			cc: 3
 		};
 
 		getter = (function(key){
@@ -80,27 +80,28 @@ describe('Function.prototype.overloadGetter', function(){
 	it('should call a getter for each argument', function(){
 		getter = getter.overloadGetter();
 
-		expect(getter('a')).toEqual(1);
-		expect(getter('b')).toEqual(2);
-		expect(getter('c')).toEqual(3);
-		expect(getter('d')).toBeNull();
+		expect(getter('aa')).toEqual(1);
+		expect(getter('bb')).toEqual(2);
+		expect(getter('cc')).toEqual(3);
+		expect(getter('dd')).toBeNull();
 
-		expect(getter('a', 'b', 'c')).toEqual(object);
-		expect(getter(['a', 'b', 'c'])).toEqual(object);
-		expect(getter(['a', 'c', 'd'])).toEqual({a: 1, c: 3, d: null});
+		expect(getter('aa', 'bb', 'cc')).toEqual(object);
+		expect(getter(['aa', 'bb', 'cc'])).toEqual(object);
+		expect(getter(['aa', 'cc', 'dd'])).toEqual({aa: 1, cc: 3, dd: null});
 	});
 
 	it('should work in plural mode', function(){
 		getter = getter.overloadGetter(true);
 
-		expect(getter('a')).toEqual({
-			a: 1
+		expect(getter('aa')).toEqual({
+			aa: 1
 		});
 
-		expect(getter(['a', 'b'])).toEqual({
-			a: 1,
-			b: 2
+		expect(getter(['aa', 'bb'])).toEqual({
+			aa: 1,
+			bb: 2
 		});
+
 	})
 
 });


### PR DESCRIPTION
The specs added in 77b223c8 passed because the length of the keys was only one character long. However IE was so kind to let us know that something wasn't exactly right :)
