### PR TITLE
Fix get style percentages opera

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -120,15 +120,17 @@ Element.implement({
 			var color = result.match(/rgba?\([\d\s,]+\)/);
 			if (color) result = result.replace(color[0], color[0].rgbToHex());
 		}
-		if (Browser.opera || (Browser.ie && isNaN(parseFloat(result)))){
-			if ((/^(height|width)$/).test(property)){
+		if (Browser.opera || Browser.ie){
+			if ((/^(height|width)$/).test(property) && !(/px$/.test(result))){
 				var values = (property == 'width') ? ['left', 'right'] : ['top', 'bottom'], size = 0;
 				values.each(function(value){
 					size += this.getStyle('border-' + value + '-width').toInt() + this.getStyle('padding-' + value).toInt();
 				}, this);
 				return this['offset' + property.capitalize()] - size + 'px';
 			}
-			if (!Browser.opera && (/^border(.+)Width|margin|padding/).test(property)) return '0px';
+			if (Browser.ie && (/^border(.+)Width|margin|padding/).test(property) && isNaN(parseFloat(result))){
+				return '0px';
+			}
 		}
 		return result;
 	},

--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -101,7 +101,14 @@ describe('Element.Style', function(){
 		});
 
 		it('should get the left margin from the CSS', function(){
-			expect(element.getStyle('margin-left')).toEqual('20%');
+			// FireFox returns px (and maybe even as floats)
+			var re = /^(20\%|(\d+|\d+\.\d+)px)$/;
+			expect(re.test('20%')).toBe(true);
+			expect(re.test('20px')).toBe(true);
+			expect(re.test('20.43px')).toBe(true);
+			expect(re.test('20')).toBe(false);
+			expect(re.test('auto')).toBe(false);
+			expect(element.getStyle('margin-left')).toMatch(re);
 		});
 
 		it('[afterAll]', function(){


### PR DESCRIPTION
This fixes `.getStyle('height')` in Opera, which returned `0px` after #2282. Before #2282 Opera didn't correctly returned `margin` when the margin was defined as `%`. That wasn't really an Opera bug, but more some extra check in the MooTools code.

It also returns px values for width/height in IE now. That is more consistent with proper browsers.
