### PR TITLE
Ie leak

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -792,6 +792,11 @@ var clean = function(item){
 		delete collected[uid];
 		delete storage[uid];
 	}
+    var props = ['_fireEvent','$family','$constructor'];
+    props.each(function(property){
+        if(property in item) delete item[property];
+    });
+    
 	return item;
 };
 
@@ -800,10 +805,11 @@ var formProps = {input: 'checked', option: 'selected', textarea: 'value'};
 Element.implement({
 
 	destroy: function(){
-        if(! this.getElementsByTagName) return null; //textNode
-		var children = clean(this).getElementsByTagName('*');
-		Array.each(children, clean);
-		Element.dispose(this);
+        if(this.nodeType == 1){
+            var children = clean(this).getElementsByTagName('*');
+            Array.each(children, clean);
+        }
+        Element.dispose(this);
 		return null;
 	},
 
@@ -813,7 +819,6 @@ Element.implement({
 	},
 
 	dispose: function(){
-        this._fireEvent = null;
 		return (this.parentNode) ? this.parentNode.removeChild(this) : this;
 	},
 
@@ -954,7 +959,7 @@ Element.Properties.html = {
 // fix for IE leak on Element.set('text','')
 Element.Properties.text = {
     set: function(text){
-        Element.prototype.empty.call(this).setProperty('text',text);
+        this.empty().setProperty('text',text);
     }
 }
 


### PR DESCRIPTION
changed empty, now it uses destroy to clean every children tree
this change need a check on destroy, because childNodes returns
textNodes
on clean i removed the _fireEvent reference breaking the circular
reference and allowing the gc to clean up the memory (tested with
sIEve-0.0.8)
set('html',...) don't leak but set('text',...) does, so added a
Element.Properties.text setter and done empty() before setting the text

I setup a test page that creates 1000 divs, added these divs to the
body and then use empty(), set('html', ...) and set('text', ...) to get
rid of them, causing a 1000 element leak,
with these changes I managed to drop the leaks from 1000 to 0.
