### PR TITLE
Fix #2357 by adding this.Element when the Element type is created.

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -14,7 +14,7 @@ provides: [Element, Elements, $, $$, Iframe, Selectors]
 ...
 */
 
-var Element = function(tag, props){
+var Element = this.Element = function(tag, props){
 	var konstructor = Element.Constructors[tag];
 	if (konstructor) return konstructor(props);
 	if (typeof tag != 'string') return document.id(tag).set(props);


### PR DESCRIPTION
Doing the following in node does not properly export the Element Type:

``` javascript
var element = require('../Source/Element/Element.js');
element.Elements; // exists
element.Element; // does not exist
```

Since it's not properly exported, it won't be possible to export it to the global context or window with wrapup.

Addining `this.Element` when defining the Element type, fixes the issue.
