### PR TITLE
fix for #2359 - IELT9 select.set('value', 0) with option with value=''

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -1021,7 +1021,7 @@ if (testForm.firstChild.value != 's') Element.Properties.value = {
 		if (tag != 'select') return this.setProperty('value', value);
 		var options = this.getElements('option');
 		value = String(value);
-        for (var i = 0; i < options.length; i++){
+		for (var i = 0; i < options.length; i++){
 			var option = options[i],
 				attr = option.getAttributeNode('value'),
 				optionValue = (attr && attr.specified) ? option.value : option.get('text');

--- a/Specs/1.4client/Element/Element.js
+++ b/Specs/1.4client/Element/Element.js
@@ -69,15 +69,15 @@ describe('Element', function(){
 				expect(new Element('input', {value: 0}).get('value')).toEqual('0');
 			});
 
-            it('should set the selected option for a select element to matching string w/o falsy matches', function(){
-                var form = new Element('form');
-                form.set('html', '<select>\
-                    <option value="">no value</option>\
+			it('should set the selected option for a select element to matching string w/o falsy matches', function(){
+				var form = new Element('form');
+				form.set('html', '<select>\
+					<option value="">no value</option>\
 					<option value="0">value 0</option>\
 					<option value="1">value 1</option>\
 					</select>');
-                expect(form.getElement('select').set('value', 0).get('value')).toEqual('0');
-            });
+				expect(form.getElement('select').set('value', 0).get('value')).toEqual('0');
+			});
 
 		});
 


### PR DESCRIPTION
was picking wrong one due to loose typing and selected value was remaing as the `<option value=""></option>`
