### PR TITLE
Fix a bug: Events broken with prototype usage

### DIFF
--- a/Source/Class/Class.Extras.js
+++ b/Source/Class/Class.Extras.js
@@ -65,7 +65,7 @@ this.Events = new Class({
 	},
 
 	fireEvent: function(type, args, delay){
-		if (!this.$events) return;
+		if (!this.$events) return this;
 
 		type = removeOn(type);
 		var events = this.$events[type];
@@ -79,7 +79,7 @@ this.Events = new Class({
 	},
 
 	removeEvent: function(type, fn){
-		if (!this.$events) return;
+		if (!this.$events) return this;
 
 		type = removeOn(type);
 		var events = this.$events[type];
@@ -91,7 +91,7 @@ this.Events = new Class({
 	},
 
 	removeEvents: function(events){
-		if (!this.$events) return;
+		if (!this.$events) return this;
 
 		var type;
 		if (typeOf(events) == 'object'){

--- a/Specs/1.3client/Class/Class.Extras.js
+++ b/Specs/1.3client/Class/Class.Extras.js
@@ -169,6 +169,14 @@ var runEventSpecs = function(type, create){
 			expect(methods).toEqual([1, 2, 3, 3]);
 		},
 
+		'should be chainable': function(){
+			var object = create();
+			object.addEvent('event', $empty).addEvent('event2', $empty);
+
+			object = create();
+			object[fire]('event')[fire]('event');
+		},
+
 		'should have isolated handlers collections': function(){
 			var object2 = create();
 			var object1 = create();


### PR DESCRIPTION
It was previously impossible to use the Events class
as part of the normal Javascript prototype hierarchy.
The '$events' property was defined on the prototype
itself which meant that code like the below would
produce unexepected results.

```
function Thing() {}
Thing.prototype = new Events();
```

All instances of Thing would end up sharing the same
object in their '$events' property because it was
defined on the prototype.  Fixing this usage (and any
usage outside Mootools Class system) is simple.

This adds appropriate tests to highlight the problem
and the changes nevessary to overcome it.
