### PR TITLE
Use the HTML5 classList API in supported browsers.

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -613,6 +613,8 @@ var pollutesGetAttribute = (function(div){
 })(document.createElement('div'));
 /* </ltIE9> */
 
+var hasClassList = !!document.createElement('div').classList;
+
 Element.implement({
 
 	setProperty: function(name, value){
@@ -694,16 +696,24 @@ Element.implement({
 		return this;
 	},
 
-	hasClass: function(className){
+	hasClass: hasClassList ? function(className) {
+    return this.classList.contains(className);
+  } : function(className){
 		return this.className.clean().contains(className, ' ');
 	},
 
-	addClass: function(className){
+	addClass: hasClassList ? function(className) {
+    this.classList.add(className);
+    return this;
+  } : function(className){
 		if (!this.hasClass(className)) this.className = (this.className + ' ' + className).clean();
 		return this;
 	},
 
-	removeClass: function(className){
+	removeClass: hasClassList ? function(className) {
+    this.classList.remove(className);
+    return this;
+  } : function(className){
 		this.className = this.className.replace(new RegExp('(^|\\s)' + className + '(?:\\s|$)'), '$1');
 		return this;
 	},


### PR DESCRIPTION
We are long overdue in supporting this API. The main reason we should add this is for perf: http://hacks.mozilla.org/2010/01/classlist-in-firefox-3-6/

Instead of changing the full className only a single class is being added/removed and engines can optimize for that.
