### PR TITLE
Fixes #2392. Solves failing element filter test in IE10.

### DIFF
--- a/Specs/1.3client/Element/Element.Style.js
+++ b/Specs/1.3client/Element/Element.Style.js
@@ -17,8 +17,18 @@ describe('Element.set opacity', function(){
 	});
 
 	it('should not remove existent filters on browsers with filters', function(){
-		var div = new Element('div');
-		if (document.html.style.filter != null && !window.opera && !Syn.browser.gecko){
+		var div = new Element('div'),
+			supports_filters;
+
+		if (Syn.browser.msie) {
+			var UA = navigator.userAgent.toLowerCase().match(/(opera|ie|firefox|chrome|version)[\s\/:]([\w\d\.]+)?.*?(safari|version[\s\/:]([\w\d\.]+)|$)/),
+				version = parseFloat(UA[2]);
+			supports_filters = (version < 10);
+		} else {
+			supports_filters = (document.html.style.filter !== null && !window.opera && !Syn.browser.gecko);
+		}
+
+		if (supports_filters){
 			div.style.filter = 'blur(strength=50)';
 			div.set('opacity', 0.4);
 			expect(div.style.filter).toMatch(/blur\(strength=50\)/i);


### PR DESCRIPTION
Added a check for IE10+ to prevent test from failing.
