### PR TITLE
Fixes #2396. Feature check for position:fixed support

### DIFF
--- a/Specs/1.3client/Element/Element.Dimensions.js
+++ b/Specs/1.3client/Element/Element.Dimensions.js
@@ -8,7 +8,25 @@ provides: [Element.Dimensions.Specs]
 */
 describe('Element.getOffsetParent', function(){
 
-	var container, offsetParent, wrapper, child, table, td;
+	var container, offsetParent, wrapper, child, table, td,
+		supportsFixedPosition = (function() {
+			var body = document.body,
+				container = document.createElement("div"),
+				fixed_div = document.createElement("div"),
+				top_offset = '1px';
+
+			container.style.cssText = "position:absolute; top: 2px; visibility:hidden";
+			fixed_div.style.cssText ='position:fixed; top:'+top_offset;
+
+			container.appendChild(fixed_div);
+			body.insertBefore( container, body.firstChild );
+
+			var coords = $(fixed_div).getCoordinates(),
+				supports_fixed_position = (coords.top === parseInt(top_offset));
+
+			body.removeChild(container);
+			return supports_fixed_position;
+		})();
 
 	beforeEach(function(){
 		container = new Element('div');
@@ -28,7 +46,7 @@ describe('Element.getOffsetParent', function(){
 		td = new Element('td').inject(new Element('tr').inject(table));
 
 		container.inject(document.body);
-		
+
 	});
 
 	it('Should return the right offsetParent', function(){
@@ -66,11 +84,10 @@ describe('Element.getOffsetParent', function(){
 	});
 
 	it('Should return null for elements with position:fixed', function(){
-
-		table.setStyle('position', 'fixed');
-
-		expect(table.getOffsetParent()).toBeNull();
-
+		if (supportsFixedPosition) {
+			table.setStyle('position', 'fixed');
+			expect(table.getOffsetParent()).toBeNull();
+		}
 	});
 
 	it('Should return null for the body element', function(){


### PR DESCRIPTION
Feature test for position:fixed support solves failing test in Windows Phone. Runs as expected in FF, Safari, Chrome on OS X and IE7+.

Setting position: fixed in Win Phone yields strange results:

element.setStyle('position', 'fixed');
element.getStyle('position') === 'fixed'
element.style.position === 'fixed'

element.currentStyle.position === 'absolute'

This was causing getOffsetParent() to return an empty div instead of null in this test.