### PR TITLE
Fixes #2316 - A DELETE request will use a querystring instead of the request body

### DIFF
--- a/Source/Request/Request.js
+++ b/Source/Request/Request.js
@@ -185,7 +185,7 @@ var Request = this.Request = new Class({
 		if (this.options.noCache)
 			url += (url.contains('?') ? '&' : '?') + String.uniqueID();
 
-		if (data && method == 'get'){
+		if (data && (method == 'get' || method == 'delete')){
 			url += (url.contains('?') ? '&' : '?') + data;
 			data = null;
 		}


### PR DESCRIPTION
see #2316
/cc @sebmarkbage
