### PR TITLE
add feature detect and fix for oldIE to normalize order of border style

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -24,6 +24,11 @@ var el = document.createElement('div');
 el.style.color = 'red';
 el.style.color = null;
 var doesNotRemoveStyles = el.style.color == 'red';
+
+// check for oldIE, which returns border* shorthand styles in the wrong order (color-width-style instead of width-style-color)
+var border = '1px solid #123abc';
+el.style.border = border;
+var returnsBordersInWrongOrder = el.style.border != border;
 el = null;
 //</ltIE9>
 
@@ -131,6 +136,11 @@ Element.implement({
 			if ((/^border(.+)Width|margin|padding/).test(property) && isNaN(parseFloat(result))){
 				return '0px';
 			}
+			//<ltIE9>
+			if (returnsBordersInWrongOrder && /^border(Top|Right|Bottom|Left)?$/.test(property) && /^#/.test(result)){
+				return result.replace(/^(.+)\s(.+)\s(.+)$/, '$2 $3 $1');
+			}
+			//</ltIE9>
 		}
 		return result;
 	},

--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -158,5 +158,14 @@ describe('Element.Style', function(){
 		});
 
 	});
+	
+	describe('getStyle border after setStyle', function(){
+
+		it('should have same order when getting a previously set border', function(){
+			var border = '2px solid #123abc';
+			expect(new Element('div').setStyle('border', border).getStyle('border')).toEqual(border);
+		});
+
+	});
 
 });


### PR DESCRIPTION
fixes #2391

let me know if the coding style is not up to par, I reused the same `el` element for the feature detect to save some bytes and runtime resources.
