### PR TITLE
Fixed a typo in the doc.

### DIFF
--- a/Docs/Element/Element.md
+++ b/Docs/Element/Element.md
@@ -207,7 +207,7 @@ Gets the first descendant element whose tag name matches the tag provided. CSS s
 Element Method: getElements {#Element:getElements}
 --------------------------------------------------
 
-Collects all decedent elements whose tag name matches the tag provided. CSS selectors may also be passed.
+Collects all descendant elements whose tag name matches the tag provided. CSS selectors may also be passed.
 
 ### Syntax:
 


### PR DESCRIPTION
Replaced 'decedent' by 'descendant'. A 'decedent' is a person who has died.
