### PR TITLE
Normalize backgroundPosition, fixes #2213 and #2295

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -122,12 +122,12 @@ Element.implement({
 			}
 			result = this.getComputedStyle(property);
 		}
-		if (hasBackgroundPositionXY && /^backgroundPosition[XY]$/.test(property) || property == 'backgroundPosition' && /(top|right|bottom|left)/.test(result)){
-			return result.replace(/(\w+)/g, function(value) { return value && namedPositions[value] || value || '0px'; }) || '0px';
+		if (hasBackgroundPositionXY && /^backgroundPosition[XY]?$/.test(property)){
+			return result.replace(/(top|right|bottom|left)/g, function(position){
+				return namedPositions[position];
+			}) || '0px';
 		}
-		if (!result && property == 'backgroundPosition') {
-			return '0px 0px';
-		}
+		if (!result && property == 'backgroundPosition') return '0px 0px';
 		if (result){
 			result = String(result);
 			var color = result.match(/rgba?\([\d\s,]+\)/);
@@ -232,7 +232,5 @@ Element.ShortStyles = {margin: {}, padding: {}, border: {}, borderWidth: {}, bor
 	Short.borderColor[bdc] = Short[bd][bdc] = All[bdc] = 'rgb(@, @, @)';
 });
 
-if (hasBackgroundPositionXY) {
-	Object.merge(Element.ShortStyles, {backgroundPosition: {backgroundPositionX: '@', backgroundPositionY: '@'}});
-}
+if (hasBackgroundPositionXY) Element.ShortStyles.backgroundPosition = {backgroundPositionX: '@', backgroundPositionY: '@'};
 })();

--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -178,7 +178,7 @@ describe('Element.Style', function(){
 	
 	describe('getStyle background-position', function(){
 		beforeEach(function(){
-			var className = String.uniqueID();
+			var className = 'getStyleBackgroundPosition';
 			var style = this.style = $(document.createElement('style'));
 			style.type = 'text/css';
 			var definition = [
@@ -202,6 +202,7 @@ describe('Element.Style', function(){
 		afterEach(function(){
 			this.style.destroy();
 			this.element.destroy();
+			this.element = null;
 		});
 		
 		it('should have non-empty background-position shorthand', function(){


### PR DESCRIPTION
several issues solved here:
- IE7 & 8 fail to return the `backgroundPosition` of an element when it was set on the stylesheet
- IE 7-8-9 (not sure about 10) return the top|right|bottom|left keywords when doing a `getStyle` if that keyword was used (7 and 8 only do it for `backgroundPosition[XY]`, they correctly normalize `backgroundPosition`)
- IE7, IE8, Chrome and Opera return an empty string on a `getStyle` over an element that has no `backgroundPosition` set

this patch normalizes all those scenarios so that all browsers return the same values (using the suggested normalization hash on #2213, plus other fixes).
If someone can test on IE10 it would be great, the fiddle I added to #2295 works fine after this patch is applied.
