### PR TITLE
opacity 1 should not have a nulling effect in oldIE, fixes #2336

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -45,16 +45,25 @@ var setVisibility = function(element, opacity){
 	element.style.visibility = opacity > 0 || opacity == null ? 'visible' : 'hidden';
 };
 
+//<ltIE9>
+var setFilter = function(element, regexp, value){
+	var style = element.style,
+		filter = style.filter || element.getComputedStyle('filter') || '';
+	style.filter = (regexp.test(filter) ? filter.replace(regexp, value) : filter + ' ' + value).trim();
+	if (!style.filter) style.removeAttribute('filter');
+};
+//</ltIE9>
+
 var setOpacity = (hasOpacity ? function(element, opacity){
 	element.style.opacity = opacity;
 } : (hasFilter ? function(element, opacity){
-	var style = element.style;
-	if (!element.currentStyle || !element.currentStyle.hasLayout) style.zoom = 1;
-	if (opacity == null || opacity == 1) opacity = '';
-	else opacity = 'alpha(opacity=' + (opacity * 100).limit(0, 100).round() + ')';
-	var filter = style.filter || element.getComputedStyle('filter') || '';
-	style.filter = reAlpha.test(filter) ? filter.replace(reAlpha, opacity) : filter + opacity;
-	if (!style.filter) style.removeAttribute('filter');
+	if (!element.currentStyle || !element.currentStyle.hasLayout) element.style.zoom = 1;
+	if (opacity == null || opacity == 1){
+		setFilter(element, reAlpha, '');
+		if (opacity == 1 && getOpacity(element) != 1) setFilter(element, reAlpha, 'alpha(opacity=100)');
+	} else {
+		setFilter(element, reAlpha, 'alpha(opacity=' + (opacity * 100).limit(0, 100).round() + ')');
+	}
 } : setVisibility));
 
 var getOpacity = (hasOpacity ? function(element){

--- a/Specs/1.3client/Element/Element.Style.js
+++ b/Specs/1.3client/Element/Element.Style.js
@@ -7,31 +7,31 @@ provides: [Element.Style.Specs]
 ...
 */
 describe('Element.set opacity', function(){
+	var hasOpacity = (document.html.style.opacity != null);
 
 	it('should return the opacity of an Element without seting it before', function(){
 		var div = new Element('div');
-		if (document.html.style.opacity != null) div.style.opacity = 0.4;
+		if (hasOpacity) div.style.opacity = 0.4;
 		else if (document.html.style.filter != null) div.style.filter = 'alpha(opacity=40)';
 		else div.setStyle('opacity', 0.4); // We only have visibility available but opacity should still report a 0..1 value
 		expect(div.get('opacity') == 0.4).toBeTruthy();
 	});
 
-	it('should not remove existent filters on browsers with filters', function(){
+	it('should not remove existent filters on browsers with non-standard filters', function(){
 		var div = new Element('div'),
-			supports_filters;
+			supportsOldFilters;
 
 		if (Syn.browser.msie) {
 			var UA = navigator.userAgent.toLowerCase().match(/(opera|ie|firefox|chrome|version)[\s\/:]([\w\d\.]+)?.*?(safari|version[\s\/:]([\w\d\.]+)|$)/),
 				version = parseFloat(UA[2]);
-			supports_filters = (version < 10);
-		} else {
-			supports_filters = (document.html.style.filter !== null && !window.opera && !Syn.browser.gecko);
+			supportsOldFilters = (document.html.style.filter != null) && (version < 9);
 		}
 
-		if (supports_filters){
+		if (supportsOldFilters){
 			div.style.filter = 'blur(strength=50)';
 			div.set('opacity', 0.4);
 			expect(div.style.filter).toMatch(/blur\(strength=50\)/i);
+			expect(div.style.filter).toEqual('blur(strength=50) alpha(opacity=40)');
 		}
 	});
 

--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -37,6 +37,7 @@ describe('Element.Style', function(){
 		afterEach(function(){
 			this.style.destroy();
 			this.element.destroy();
+			this.element = null;
 		});
 
 		it('should get the opacity defined by the CSS', function(){
@@ -44,14 +45,10 @@ describe('Element.Style', function(){
 		});
 
 		it('should set/overwrite the opacity', function(){
-			// this test is disabled in IE, because of the ugly aliasing with
-			// opacity we have to remove the filter in oldIE
-			if (document.html.style.filter == null || window.opera || Syn.browser.gecko){
-				this.element.setStyle('opacity', 1);
-				expect(this.element.getStyle('opacity')).toEqual(1);
-				this.element.setStyle('opacity', null);
-				expect(this.element.getStyle('opacity')).toEqual(0.5);
-			}
+			this.element.setStyle('opacity', 1);
+			expect(this.element.getStyle('opacity')).toEqual(1);
+			this.element.setStyle('opacity', null);
+			expect(this.element.getStyle('opacity')).toEqual(0.5);
 		});
 
 		it('should remove the style by setting it to `null`', function(){


### PR DESCRIPTION
this also re-enables the opacity spec to run on IE, test case on #2336 also works with this modification.

The issue is that there was an incorrect assumption that `setStyle('opacity', 1)` meant removing the filter attribute as if 1 was the default, when in fact the element could have any other opacity set at the stylesheet level.
Enabled specs are green, pinging @cpojer in case he had some reason for interpreting 1 as null and I'm missing an obscure IE bug that is not showing with the current specs (does an @ mention actually ping the user? :) )

relevant commit that introduced this regression: https://github.com/mootools/mootools-core/commit/041141377eb41960a58f18094cf17f41be1cd347
