### PR TITLE
only try to normalize the units to px on IE if it's not set on style attribute

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -142,7 +142,7 @@ Element.implement({
 			if (color) result = result.replace(color[0], color[0].rgbToHex());
 		}
 		if (Browser.opera || Browser.ie){
-			if ((/^(height|width)$/).test(property) && !(/px$/.test(result))){
+			if ((/^(height|width)$/).test(property) && !(/px$/.test(result)) && !this.style[property]){
 				var values = (property == 'width') ? ['left', 'right'] : ['top', 'bottom'], size = 0;
 				values.each(function(value){
 					size += this.getStyle('border-' + value + '-width').toInt() + this.getStyle('padding-' + value).toInt();

--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -96,6 +96,14 @@ describe('Element.Style', function(){
 		it('should get the width from the CSS', function(){
 			expect(element.getStyle('width')).toMatch(/\d+px/);
 		});
+		
+		it('should not mangle the units from inline width in %', function(){
+			expect(new Element('div').setStyle('width', '40%').getStyle('width')).toEqual('40%');
+		});
+		
+		it('should not mangle the units from inline auto width', function(){
+			expect(new Element('div').setStyle('width', 'auto').getStyle('width')).toEqual('auto');
+		});
 
 		it('should get the left margin from the CSS', function(){
 			// FireFox returns px (and maybe even as floats)


### PR DESCRIPTION
After reading this [StackOverflow question](http://stackoverflow.com/questions/12083523/return-element-actual-property-width-not-px-ie) I noticed the IE normalization code on `getStyle` was also overriding a style that was directly set on the element, so if for example you set a style on a non-px based unit, a later getStyle would mangle that unit back into px.
This patch simply avoids running the normalization if the return value was directly set on the element, so that IE can behave just like any other browser.

I know @ibolmo is running a drive to refactor this on #2414 but this is just another thing he will need to take into account when refactoring (adds 2 tests) and improves our robustness right now.
