### PR TITLE
In Request.HTML all script tags are evaluated despite a filter selector is being used

### DIFF
--- a/Source/Request/Request.HTML.js
+++ b/Source/Request/Request.HTML.js
@@ -30,14 +30,21 @@ Request.HTML = new Class({
 
 	success: function(text){
 		var options = this.options, response = this.response;
-
-		response.html = text.stripScripts(function(script){
-			response.javascript = script;
-		});
+    
+    response.html = text;
 
 		var match = response.html.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
 		if (match) response.html = match[1];
-		var temp = new Element('div').set('html', response.html);
+		var temp = new Element('div', {html: response.html});
+
+    if (options.filter)
+      response.html = temp.getElement(options.filter).outerHTML;
+
+		response.html = response.html.stripScripts(function(script){
+			response.javascript = script;
+		});
+
+		temp = new Element('div', {html: response.html});
 
 		response.tree = temp.childNodes;
 		response.elements = temp.getElements(options.filter || '*');

--- a/Specs/1.3client/Request/Request.HTML.js
+++ b/Specs/1.3client/Request/Request.HTML.js
@@ -157,7 +157,7 @@ describe('Request.HTML', function(){
 
 	it('should create an ajax request and correctly filter it by the passed selector', function(){
 
-		var response = '<span>text</span><a>aaa</a>';
+		var response = '<span>text</span><script>___SPEC___=1;</script><a>aaa<script>___SPEC___=2;</script></a><script>___SPEC___=3;</script>';
 
 		this.spy.identity = 'Request.HTML onComplete filter';
 		var request = new Request.HTML({
@@ -173,7 +173,8 @@ describe('Request.HTML', function(){
 		expect(onCompleteArgs[0].length).toEqual(1);
 		expect(onCompleteArgs[0][0].get('tag')).toEqual('a');
 		expect(onCompleteArgs[0][0].get('text')).toEqual('aaa');
-
+		expect(onCompleteArgs[3].trim()).toEqual('___SPEC___=2;');
+		expect(___SPEC___).toEqual(2);
 	});
 
 	it('should create an ajax request that filters the response and updates the target', function(){


### PR DESCRIPTION
Script tags should be also filtered when using a filter criteria IMHO.
