### PR TITLE
XHR Level 2 responseType of arrayBuffer and Blob

### DIFF
--- a/Docs/Request/Request.md
+++ b/Docs/Request/Request.md
@@ -88,10 +88,10 @@ Fired when the Request is making progresses in the download or upload. (This is 
 	myRequest.send();
 
 	var mySound = new Request({
-		method: 	'get',
-		url:		'squarepusher.wav',
+		method: 'get',
+		url: 'squarepusher.wav',
 		responseType: 'arraybuffer',
-		onSuccess:	function(res){
+		onSuccess: function(res){
 			myAudioContext.decodeAudioData(res, function(buffer){
 				if (buffer) myAudioBuffer = buffer;
 			});

--- a/Source/Request/Request.js
+++ b/Source/Request/Request.js
@@ -74,20 +74,21 @@ var Request = this.Request = new Class({
 		if (progressSupport) xhr.onprogress = xhr.onloadstart = empty;
 		clearTimeout(this.timer);
 
-		if (this.options.responseType 
-		 && (this.options.responseType == 'arraybuffer' || this.options.responseType == 'blob') ){
+		if (this.options.responseType && (this.options.responseType == 'arraybuffer' || this.options.responseType == 'blob')){
 			this.response = {};
 			this.response[this.options.responseType] = this.xhr.response || '';
-			if (this.options.isSuccess.call(this, this.status))
+			if (this.options.isSuccess.call(this, this.status)){
 				this.success(this.response[this.options.responseType]);
-			else
+			} else {
 				this.failure();
+			}
 		} else {
 			this.response = {text: this.xhr.responseText || '', xml: this.xhr.responseXML};
-			if (this.options.isSuccess.call(this, this.status))
+			if (this.options.isSuccess.call(this, this.status)){
 				this.success(this.response.text, this.response.xml);
-			else
+			} else {
 				this.failure();
+			}
 		}
 	},
 


### PR DESCRIPTION
This pull request in response to the below mails on the MT users' list.

The change is that a new option has been added to Requestjs, 'responseType.' Valid values are not checked, but passed directly to the xhr object just after it has been open()ed.

A callback could not be used to do this, as the xhr object is never exposed in an existing callback, and exposing it seemed contrary to the spirit of the code. Furthermore, this is base functionality of XHR, at level two, and is required for requests of HTML5 audio data via the Web Audio API (at least), so without this support, MooTools cannot be used with HTML5 Web Audio.

Please let me know what you think.

On 08/10/2012 05:09, Barry van Oudtshoorn wrote:

> This sounds like it'd be something that could reasonably be exposed as an option on the Request class, so my recommendation would be to alter that class and send a pull request. No guarantee that it'll be accepted, of course, but this is certainly the way that I'd want to interact with this in MooTools. It's a pretty fundamental operation on XHR, to be honest, so I think it's worthwhile.
> 
> On 07/10/12 17:22, Lee Goddard wrote:
> 
> > I'm making XHR requets with reponseType set to 'arraybuffer', so that I can receive binary data to pass to a Web Audio API audio context's decodeAudioData() method.
> > 
> > As far as I know, this cannot be done with MooTools as it stands, because although I could sub-class Request and adjust the onStateChange() and success(), access is required to the private XHR so that the responseType can be set after the requested is open()ed.
> > 
> > Over-riding the send() method seems like a bad idea, as I'd have to keep it updated with any change made to the core.
> > 
> > The only solution I can see is to expose the currently-private xhr object, but I guess it is private for a reason.
> > 
> > Does anyone have any suggestions, please?
> > 
> > TIA
> > Lee 
