### PR TITLE
Fix delegation issue introduced in 1.4.2, #2367.

### DIFF
--- a/Source/Element/Element.Delegation.js
+++ b/Source/Element/Element.Delegation.js
@@ -123,6 +123,12 @@ var relay = function(old, method){
 	};
 };
 
+var addMatchCondition = function (type, match, condition) {
+	return function(target, event){
+		return match(target, event) && condition.call(target, event, type);
+	};
+};
+
 var delegation = {
 
 	addEvent: function(type, match, fn){
@@ -140,10 +146,12 @@ var delegation = {
 
 		var elementEvent = Element.Events[_type];
 		if (elementEvent && elementEvent.condition){
-			var __match = match, condition = elementEvent.condition;
-			match = function(target, event){
-				return __match(target, event) && condition.call(target, event, type);
-			};
+			match = addMatchCondition(type, match, elementEvent.condition);
+		} else {
+			elementEventCondition = Element.NativeEventsConditions[_type];
+			if (elementEventCondition){
+				match = addMatchCondition(type, match, elementEventCondition);
+			}
 		}
 
 		var self = this, uid = String.uniqueID();

--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -145,17 +145,20 @@ Element.NativeEvents = {
 Element.Events = {mousewheel: {
 	base: (Browser.firefox) ? 'DOMMouseScroll' : 'mousewheel'
 }};
+Element.NativeEventsConditions = {};
+
+var check = function(event){
+	var related = event.relatedTarget;
+	if (related == null) return true;
+	if (!related) return false;
+	return (related != this && related.prefix != 'xul' && typeOf(this) != 'document' && !this.contains(related));
+};
 
 if ('onmouseenter' in document.documentElement){
 	Element.NativeEvents.mouseenter = Element.NativeEvents.mouseleave = 2;
+	Element.NativeEventsConditions.mouseenter = check;
+	Element.NativeEventsConditions.mouseleave = check;
 } else {
-	var check = function(event){
-		var related = event.relatedTarget;
-		if (related == null) return true;
-		if (!related) return false;
-		return (related != this && related.prefix != 'xul' && typeOf(this) != 'document' && !this.contains(related));
-	};
-
 	Element.Events.mouseenter = {
 		base: 'mouseover',
 		condition: check


### PR DESCRIPTION
In `1.4.2` mootools uses native `mouseenter` and `mouseleave` if available. Though, those can not be used in delegation because they don't bubble.

The problem lies in:

``` js
var elementEvent = Element.Events[_type];
if (elementEvent && elementEvent.condition){
  var __match = match, condition = elementEvent.condition;
  match = function(target, event){
    return __match(target, event) && condition.call(target, event, type);
  };
}
```

The `type` variable was being correctly translated from `mouseenter`  to `mouseover` and `mouseleave` to `mouseou`. When mootools was using the native version, `Element.Events[_type]` was not being set, causing the `if` condition to be always false.

Worth mentioning that this problem was not only related to tables and table rows/cells. It was present everywhere.
Check this fiddle that replicates the problem with divs: http://jsfiddle.net/WysPu/1
This PR proposes a fix for this, feel free to suggest modifications to the code in order to get merged. This problem was causing us to use `1.4.1` in a project for too long.
