### PR TITLE
Fixing a missing closing quote in the Mootools Docs.

### DIFF
--- a/Docs/Element/Element.md
+++ b/Docs/Element/Element.md
@@ -168,7 +168,7 @@ Creates a new Element of the type passed in.
 
 ### Note:
 
-Because the element name is parsed as a CSS selector, colons in namespaced tags have to be escaped. So `new Element('fb\:name)` becomes `<fb:name>`.
+Because the element name is parsed as a CSS selector, colons in namespaced tags have to be escaped. So `new Element('fb\:name')` becomes `<fb:name>`.
 
 ### See Also:
 


### PR DESCRIPTION
Added missing closing quote to the example of element construction with namespace.
