### PR TITLE
Set this.Window and this.Document to null on unload. #2329

### DIFF
--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -161,10 +161,9 @@ if (document.execCommand) try {
 /*<ltIE9>*/
 if (this.attachEvent && !this.addEventListener){
 	var unloadEvent = function(){
-	  this.detachEvent('onunload', unloadEvent);
-	  document.head = document.html = document.window = null;
-	  // cleanup scope vars
-	  window = this.Window = document = null;
+		this.detachEvent('onunload', unloadEvent);
+		document.head = document.html = document.window = null;
+		window = this.Window = document = null;
 	};
 	this.attachEvent('onunload', unloadEvent);
 }

--- a/Source/Utilities/DOMReady.js
+++ b/Source/Utilities/DOMReady.js
@@ -24,15 +24,15 @@ var ready,
 	testElement = document.createElement('div');
 
 var domready = function(){
-  clearTimeout(timer);
-  if (!ready) {
-    Browser.loaded = ready = true;
-    document.removeListener('DOMContentLoaded', domready).removeListener('readystatechange', check);
-    document.fireEvent('domready');
-    window.fireEvent('domready');
-  }
-  // cleanup scope vars
-  document = window = testElement = null;
+	clearTimeout(timer);
+	if (!ready) {
+		Browser.loaded = ready = true;
+		document.removeListener('DOMContentLoaded', domready).removeListener('readystatechange', check);
+		document.fireEvent('domready');
+		window.fireEvent('domready');
+	}
+	// cleanup scope vars
+	document = window = testElement = null;
 };
 
 var check = function(){


### PR DESCRIPTION
Fix for issue #2329

Tested in IE7, 8, 9 and 10, and the latest releases Firefox and Chrome.
Frees up large amounts of memory when navigating away from a page.
