### PR TITLE
Fix #2428 IE8: Fx.Morph percentage unit issue

### DIFF
--- a/Source/Fx/Fx.CSS.js
+++ b/Source/Fx/Fx.CSS.js
@@ -28,7 +28,7 @@ Fx.CSS = new Class({
 			from = element.getStyle(property);
 			var unit = this.options.unit;
 			// adapted from: https://github.com/ryanmorr/fx/blob/master/fx.js#L299
-			if (unit && from && typeof from == 'string' && from.slice(-unit.length) != unit && parseFloat(from) != 0){
+			if (unit && from && typeof from == 'string' && from.slice(-unit.length) != unit && parseFloat(from) != 0 && !isNaN(parseFloat(from))){
 				element.setStyle(property, to + unit);
 				var value = element.getComputedStyle(property);
 				// IE and Opera support pixelLeft or pixelWidth


### PR DESCRIPTION
This pull request fixes the unit issue in the Fx.CSS class.
Indeed, we can not morph a property using a specific unit (let say %) and a color property at the same time.
This example fails:

```
el.set("morph", {
    "duration": 1000,
    "unit": "%"
});
el.get("morph").start({
    "height": "50",
    "background-color": "#00FF00"
});
```

The animation on the background-color does not work.
