### PR TITLE
Fix event.key for keypress.

### DIFF
--- a/Source/Types/DOMEvent.js
+++ b/Source/Types/DOMEvent.js
@@ -45,7 +45,7 @@ var DOMEvent = this.DOMEvent = new Type('DOMEvent', function(event, win){
 
 	if (type.indexOf('key') == 0){
 		var code = this.code = (event.which || event.keyCode);
-		this.key = _keys[code]/*<1.3compat>*/ || Object.keyOf(Event.Keys, code)/*</1.3compat>*/;
+		this.key = !this.shift && (_keys[code]/*<1.3compat>*/ || Object.keyOf(Event.Keys, code)/*</1.3compat>*/);
 		if (type == 'keydown' || type == 'keyup'){
 			if (code > 111 && code < 124) this.key = 'f' + (code - 111);
 			else if (code > 95 && code < 106) this.key = code - 96;

--- a/Specs/Element/Element.Event.js
+++ b/Specs/Element/Element.Event.js
@@ -362,6 +362,68 @@ describe('Element.Event keyup with f<key>', function(){
 
 });
 
+describe('Keypress key code', function(){
+
+	/*<ltIE8>*/
+	// return early for IE8- because Syn.js does not fire events
+	if (!document.addEventListener) return;
+	/*</ltIE8>*/
+
+	var input, key, shift, done;
+
+	function keyHandler(e){
+		key = e.key;
+		shift = !!e.event.shiftKey;
+	}
+
+	function typeWriter(action){
+		setTimeout(function () {
+			Syn.type(action, 'keyTester');
+		}, 1);
+		if (done) return true;
+	}
+
+	beforeEach(function(){
+		input = new Element('input', {
+			'type': 'text',
+			'id': 'keyTester'
+		}).addEvent('keypress', keyHandler).inject(document.body);
+	});
+
+	afterEach(function(){
+		input.removeEvent('keypress', keyHandler).destroy();
+		input = key = shift = done = null;
+	});
+
+	it('should return "enter" in event.key', function(){
+		typeWriter('[enter]');
+		waits(50);
+		runs(function(){
+			expect(key).toBe('enter');
+			expect(shift).not.toBeTruthy();
+		});
+	});
+
+	it('should return "1" in event.key', function(){
+		typeWriter('1');
+		waits(50);
+		runs(function(){
+			expect(key).toBe('1');
+			expect(shift).not.toBeTruthy();
+		});
+	});
+
+	it('should return false when pressing SHIFT + 1', function(){
+		typeWriter('[shift]![shift-up]');
+		waits(50);
+		runs(function(){
+			expect(key).toBe(false);
+			expect(shift).toBeTruthy();
+		});
+	});
+
+});
+
 describe('Element.removeEvent', function(){
 
 	it('should remove the onunload method', function(){


### PR DESCRIPTION
 It doesn't need to lookup keynames with keypress and shift

https://github.com/mootools/mootools-more/issues/1194

jsfiddle: http://jsfiddle.net/6xf4M/

With `keypress` shift+1 generates `keyCode` 33, which maps to `pageup` when this is added with `defineKeys`.