### PR TITLE
Get the correct width and height for svg elements in firefox

### DIFF
--- a/Source/Element/Element.Dimensions.js
+++ b/Source/Element/Element.Dimensions.js
@@ -53,7 +53,7 @@ Element.implement({
 		var width = this.offsetWidth;
 		var height = this.offsetHeight;
 
-		if (width === undefined || height === undefined) && this.getBoundingClientRect) {
+		if ((width === undefined || height === undefined) && this.getBoundingClientRect) {
 			
 			var bound = this.getBoundingClientRect();
 


### PR DESCRIPTION
This commit fixes #2506

In firefox the offsetParent of svg returns undefined so i implemented a
fallback to getCBoundingClientRect to get the right ones
