### PR TITLE
fallback to getComputedStyle when offset is undefined fix #2506

### DIFF
--- a/Source/Element/Element.Dimensions.js
+++ b/Source/Element/Element.Dimensions.js
@@ -49,7 +49,10 @@ Element.implement({
 
 	getSize: function(){
 		if (isBody(this)) return this.getWindow().getSize();
-		return {x: this.offsetWidth, y: this.offsetHeight};
+		return {
+			x: this.offsetWidth  || styleNumber(this, 'width'), 
+			y: this.offsetHeight || styleNumber(this, 'height')
+		};
 	},
 
 	getScrollSize: function(){


### PR DESCRIPTION
On Firefox, offsetWidth and offsetHeight are undefined on a SVG element

See :  https://bugzilla.mozilla.org/show_bug.cgi?id=649285
Working fiddle : http://jsfiddle.net/dDbxg/7/
