### PR TITLE
When using HTML5 classList API, do not allow empty strings or white-spac...

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -703,7 +703,7 @@ Element.implement({
 	},
 
 	addClass: hasClassList ? function(className) {
-		this.classList.add(className);
+		if (className.trim()) this.classList.add(className);
 		return this;
 	} : function(className){
 		if (!this.hasClass(className)) this.className = (this.className + ' ' + className).clean();
@@ -711,7 +711,7 @@ Element.implement({
 	},
 
 	removeClass: hasClassList ? function(className) {
-		this.classList.remove(className);
+		if (className.trim()) this.classList.remove(className);
 		return this;
 	} : function(className){
 		this.className = this.className.replace(new RegExp('(^|\\s)' + className + '(?:\\s|$)'), '$1');


### PR DESCRIPTION
...e only strings else it throws errors.

@cpojer @arian 

per my comments here: 

https://github.com/mootools/mootools-core/commit/bd6ac113600fa508017c29237cf03c36171e9603#commitcomment-4646572

This commit just ensures you don't get errors if empty strings are passed to addClass/removeClass.
