### PR TITLE
Antecipated backgroundPosition check

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -147,12 +147,12 @@ Element.implement({
 		if (property == 'opacity') return getOpacity(this);
 		property = (property == 'float' ? floatName : property).camelCase();
 		var result = this.style[property];
+		if (!result && property == 'backgroundPosition') return '0px 0px';
 		if (hasBackgroundPositionXY && /^backgroundPosition[XY]?$/.test(property)){
 			return result.replace(/(top|right|bottom|left)/g, function(position){
 				return namedPositions[position];
 			}) || '0px';
 		}
-		if (!result && property == 'backgroundPosition') return '0px 0px';
 		if (!result || property == 'zIndex'){
 			if (Element.ShortStyles.hasOwnProperty(property)){
 				result = [];


### PR DESCRIPTION
When element has no background-position values or after this happens in the testing:
`element.setStyle('background-position', null);` 

Then inside getStyle:

```
var result = this.style[property];       // gives ""
if (!result || property == 'zIndex'){    //gives true from !result
```

So it goes inside the `if` and calls `result = this.getComputedStyle(property);` 
which is in FF `"0% 0%"` and therefore the Specs error `Expected '0% 0%' to equal '0px 0px'.`

So by changing the order here it returns `'0px 0px'` and makes FF happy and the error/bug for
`'background-position'` goes away
