### PR TITLE
make test more lax so it accepts either 0px 0px or 0% 0% as valid defaul...

### DIFF
--- a/Specs/1.4client/Element/Element.Style.js
+++ b/Specs/1.4client/Element/Element.Style.js
@@ -237,7 +237,7 @@ describe('Element.Style', function(){
 			var element = new Element('div');
 			element.setStyle('background-position', '40px 10px');
 			element.setStyle('background-position', null);
-			expect(element.getStyle('background-position')).toEqual('0px 0px');
+			expect(element.getStyle('background-position')).toMatch(/0px 0px|0% 0%/);
 		});
 
 	});


### PR DESCRIPTION
...t values for background-position

This fixes the failing tests on IE11 and Firefox as their reported defaults are in percentage units instead of pixels. Going forward with this as discussed on #2554 
