### PR TITLE
remove feature check for Presto

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -32,20 +32,7 @@ var returnsBordersInWrongOrder = el.style.border != border;
 el = null;
 //</ltIE9>
 
-var hasGetComputedStyle = !!window.getComputedStyle,
-	brokenGetComputedStyle = !hasGetComputedStyle; // Opera rounds sub-pixel values
-
-//<opera>
-if (hasGetComputedStyle){
-	el = document.createElement('div');
-	el.style.display = 'none';
-	var padding = el.style.paddingLeft = '1.5px';
-	document.html.appendChild(el);
-	brokenGetComputedStyle = window.getComputedStyle(el, null).paddingLeft != padding;
-	document.html.removeChild(el);
-	el = null;
-}
-//</opera>
+var hasGetComputedStyle = !!window.getComputedStyle;
 
 Element.Properties.styles = {set: function(styles){
 	this.setStyles(styles);
@@ -112,7 +99,7 @@ var removeStyle = function(style, property){
 Element.implement({
 
 	getComputedStyle: function(property){
-		if ((!hasGetComputedStyle || brokenGetComputedStyle) && this.currentStyle) return this.currentStyle[property.camelCase()];
+		if (!hasGetComputedStyle && this.currentStyle) return this.currentStyle[property.camelCase()];
 		var defaultView = Element.getDocument(this).defaultView,
 			computed = defaultView ? defaultView.getComputedStyle(this, null) : null;
 		return (computed) ? computed.getPropertyValue((property == floatName) ? 'float' : property.hyphenate()) : '';
@@ -166,7 +153,7 @@ Element.implement({
 			var color = result.match(/rgba?\([\d\s,]+\)/);
 			if (color) result = result.replace(color[0], color[0].rgbToHex());
 		}
-		if ((!hasGetComputedStyle || brokenGetComputedStyle) && !this.style[property]){
+		if (!hasGetComputedStyle && !this.style[property]){
 			if ((/^(height|width)$/).test(property) && !(/px$/.test(result))){
 				var values = (property == 'width') ? ['left', 'right'] : ['top', 'bottom'], size = 0;
 				values.each(function(value){


### PR DESCRIPTION
removing this check [as discussed](https://github.com/mootools/mootools-core/commit/912a23600d64d9c8030a58c700ac6617e09475ca#commitcomment-5228993), this code was intended to avoid using `getComputedStyle` on Presto as that engine used to round sub-pixel sizes. Now that Presto is gone in favor of Blink this check doesn't make any more sense (this code didn't get as part of a release yet, so we shouldn't even expect regressions other than a broken test on Presto)
