### PR TITLE
Element.Style compat fixes

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -103,7 +103,7 @@ Element.implement({
 			var color = result.match(/rgba?\([\d\s,]+\)/);
 			if (color) result = result.replace(color[0], color[0].rgbToHex());
 		}
-		if (Browser.Engine.presto || (Browser.Engine.trident && !$chk(parseInt(result, 10)))){
+		if (!window.getComputedStyle && !$chk(parseInt(result, 10))){
 			if (property.test(/^(height|width)$/)){
 				var values = (property == 'width') ? ['left', 'right'] : ['top', 'bottom'], size = 0;
 				values.each(function(value){

--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -530,7 +530,7 @@ Element.implement({
 	},
 
 	getComputedStyle: function(property){
-		if (this.currentStyle) return this.currentStyle[property.camelCase()];
+		if (!window.getComputedStyle && this.currentStyle) return this.currentStyle[property.camelCase()];
 		var computed = this.getDocument().defaultView.getComputedStyle(this, null);
 		return (computed) ? computed.getPropertyValue([property.hyphenate()]) : null;
 	},


### PR DESCRIPTION
This is a series of patches backporting several feature detects that superseded browser sniffing techniques in the interim between 1.2.x and 1.4.x/1.5 and enable IE11 to work correctly with the 1.2 branch 

No tests related to these were failing, but the 1.2.x test coverage is very poor so probably new tests would have been needed to show it failing (not sure if I even did this right, I took the edge test suite and ran the 1.2 specs against the 1.2.x branch source code). Let me know otherwise if testing is done differently on that branch or if we should add coverage for these cases.
