### PR TITLE
Browser ie11

### DIFF
--- a/Docs/Browser/Browser.md
+++ b/Docs/Browser/Browser.md
@@ -12,13 +12,6 @@ Browser.Features {#Browser:Browser-Features}
 * Browser.Features.json - (*boolean*) True if the browser has a native JSON object.
 * Browser.Features.xhr - (*boolean*) True if the browser supports native XMLHTTP object.
 
-Browser.Plugins {#Browser:Browser-Plugins}
-------------------------------------------
-
-* Browser.Plugins.Flash - (*object*) - An object with properties corresponding to the `version` and `build` number of the installed Flash plugin. Note: if flash is not installed, both `Browser.Plugins.Flash.version` and `Browser.Plugins.Flash.build` will return zero.
-* Browser.Plugins.Flash.version - (*number*) The major version of the flash plugin installed.
-* Browser.Plugins.Flash.build - (*number*) The build version of the flash plugin installed.
-
 Browser.Request {#Browser:Browser-Request}
 ------------------------------------------
 
@@ -55,8 +48,7 @@ Browser.name {#Browser:Browser-name}
 
 'Browser.name' reports the name of the Browser as string, identical to the property names of the following Boolean values:
 
-* Browser.ie - (*boolean*) True if the current browser is Internet Explorer &lt;= 10.
-* Browser.modernie - (*boolean*) True if the current browser is Internet Explorer &gt;= 11.
+* Browser.ie - (*boolean*) True if the current browser is Internet Explorer.
 * Browser.firefox - (*boolean*) True if the current browser is Firefox.
 * Browser.safari - (*boolean*) True if the current browser is Safari.
 * Browser.chrome - (*boolean*) True if the current browser is Chrome.
@@ -71,7 +63,7 @@ If 'Browser.chrome' is True, all other possible properties, like 'Browser.firefo
 	alert(Browser.name); // Alerts "ie" in Internet Explorer, "firefox" in Mozilla Firefox, "chrome" in Google Chrome, "safari" or "opera".
 
 	if (Browser.ie){
-		// This code will only run in IE &lt;= 10
+		// This code will only run in IE
 	}
 
 	if (Browser.firefox2){
@@ -84,9 +76,11 @@ If 'Browser.chrome' is True, all other possible properties, like 'Browser.firefo
 
 If an IE document is set to backwards compatibility mode using the X-UA-Compatible header, then the Browser object is treated as if the earlier version of the browser is running.
 
-### Browser.ie vs. Browser.modernie:
+### Browser.ie in the compatibility build:
 
-The primary use of `Browser.ie` is activating "legacy code", such "legacy code" is no longer required in more recent versions of Internet Explorer (and may not even work anymore). Having `Browser.ie == true` for modern IE in this deprecated functionality would do more harm than good, even though it's technically correct. Since this functionality is deprecated, this technical incorrectness shouldn't cause any problems. Moreover, `Browser.ie11` will still work and `Browser.name` will still equal "ie".
+In the compatibility build, for IE&gt;=11, `Browser.ie` will remain `undefined`. See below:
+
+The primary use of `Browser.ie` is activating "legacy code", such "legacy code" is no longer required in more recent versions of Internet Explorer (and may not even work anymore). Changing `Browser.ie == true` for modern IE (IE &gt;= 11) in the compatibility build would do more harm than good, even though it's technically correct. Since we did not want to break existing projects that have come to rely on `Browser.ie` not being true for the newer version(s) of IE, the compatibility build will not set `Browser.ie` for these versions of IE. However, `Browser.ie11` will work correctly and `Browser.name` will equal "ie".
 
 Browser.version {#Browser:Browser-version}
 ------------------------------------------
@@ -112,6 +106,15 @@ Browser.Platform {#Browser:Browser-Platform}
 * Browser.Platform.webos - (*boolean*) True if the platform is WebOS
 * Browser.Platform.other - (*boolean*) True if the platform is neither Mac, Windows, Linux, Android, WebOS nor iOS.
 * Browser.Platform.name - (*string*) The name of the platform.
+
+Browser.Plugins {#Browser:Browser-Plugins}
+------------------------------------------
+
+**Important note:** The *Browser.Engine* object is deprecated since MooTools 1.5, and only available in the 1.4-compatibility version.
+
+* Browser.Plugins.Flash - (*object*) - An object with properties corresponding to the `version` and `build` number of the installed Flash plugin. Note: if flash is not installed, both `Browser.Plugins.Flash.version` and `Browser.Plugins.Flash.build` will return zero.
+* Browser.Plugins.Flash.version - (*number*) The major version of the flash plugin installed.
+* Browser.Plugins.Flash.build - (*number*) The build version of the flash plugin installed.
 
 Browser.Engine {#Browser:Browser-Engine}
 ----------------------------------------

--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -62,15 +62,13 @@ Browser.extend({
 	parse: parse
 });
 
-if (Browser.name == 'ie'){
-	if (Browser.version >= '11') {
-		Browser.modernie = true;
-	} else {
-		Browser.ie = true;
-	}
-} else {
-	Browser[Browser.name] = true;
+Browser[Browser.name] = true;
+
+//<1.4compat>
+if (Browser.name == 'ie' && Browser.version >= '11') {
+	delete Browser.ie;
 }
+//</1.4compat>
 
 Browser[Browser.name + parseInt(Browser.version, 10)] = true;
 Browser.Platform[Browser.Platform.name] = true;

--- a/Specs/Browser/Browser.js
+++ b/Specs/Browser/Browser.js
@@ -78,7 +78,7 @@ describe('Browser', function(){
 
 	it('should think it is executed in a browser', function(){
 		var isPhantomJS = !!navigator.userAgent.match(/phantomjs/i);
-		expect(isPhantomJS || Browser.ie || Browser.modernie || Browser.safari || Browser.chrome || Browser.firefox || Browser.opera).toEqual(true);
+		expect(isPhantomJS || Browser.ie || Browser.safari || Browser.chrome || Browser.firefox || Browser.opera).toEqual(true);
 	});
 
 	it('should assume the IE version is emulated by the documentMode (X-UA-Compatible)', function(){


### PR DESCRIPTION
Updates for specs and docs, and an optional last commit which is explained below:

Apparently after we decided on just doing the `Browser.modernie` thing in all builds, some people suddenly started having issues with it anyway. I don't feel like going through all of this again, so the last commit in my branch supports a second option we have.

Summary:
- Current state (1.4.5):
  - IE11 detection broken
- Desired state (1.5):
  - Option 1:
    - For all builds: Differentiate between IE>=10 (`Browser.ie`) and IE<=11 (`Browser.modernie`). This is to protect people from "just" using `Browser.ie` and treating them equally bad.
  - Option 2:
    - For no-compat build: Fix IE11 detection (i.e. all IE is once again `Browser.ie`). This is technically+semantically correct.
    - For compat build: Differentiate between IE>=10 (`Browser.ie`) and IE<=11 (`Browser.modernie`). This is to make sure we don't break existing projects that (implicitly or explicitly) rely on `Browser.ie` being falsy for IE11.
  - Option 3:
    - For all builds: Fix IE11 detection (i.e. all IE is once again `Browser.ie`). **Breaking change,** so this is not feasible, the compat build should remain compatible.
  - Option 4:
    - For no-compat build: `Browser.ie` is true.
    - For compat build: `Browser.ie` is `undefined`.
- State of pull request:
  - Implemented option 4: Least amount of changes since 1.4. Fixes the IE11 issue in the most conservative way, until a decision is reached regarding the other option(s).
  - Ready to be pulled.
