### PR TITLE
Use Element.matches if available

### DIFF
--- a/Source/Slick/Slick.Finder.js
+++ b/Source/Slick/Slick.Finder.js
@@ -162,7 +162,7 @@ local.setDocument = function(document){
 
 		// native matchesSelector function
 
-		features.nativeMatchesSelector = root.matchesSelector || /*root.msMatchesSelector ||*/ root.mozMatchesSelector || root.webkitMatchesSelector;
+		features.nativeMatchesSelector = root.matches || /*root.msMatchesSelector ||*/ root.mozMatchesSelector || root.webkitMatchesSelector;
 		if (features.nativeMatchesSelector) try {
 			// if matchesSelector trows errors on incorrect sintaxes we can use it
 			features.nativeMatchesSelector.call(root, ':slick');


### PR DESCRIPTION
Spec:
http://dom.spec.whatwg.org/#dom-element-matches

Support in Chromium:
https://code.google.com/p/chromium/issues/detail?id=326652

Element.matchesSelector was never standardized and it is not available
in the most recent versions of Blink, Gecko, Presto, Trident or WebKit.
