### PR TITLE
Updating mouse wheel to support dom level 3 on wheel standard event

### DIFF
--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -144,7 +144,7 @@ Element.NativeEvents = {
 
 Element.Events = {
 	mousewheel: {
-		base: "onwheel" in document.createElement("div") ? "wheel" : document.onmousewheel !== undefined ? "mousewheel" : "DOMMouseScroll"
+		base: 'onwheel' in document ? 'wheel' : 'onmousewheel' in document ? 'mousewheel' : 'DOMMouseScroll'
 	}
 };
 


### PR DESCRIPTION
Updating mouse wheel to support dom level 3 on wheel standard event, as
per https://developer.mozilla.org/en-US/docs/Web/Reference/Events/wheel

on wheel will be used on all level 3 standard compliant browser, on
mouse wheel on the browser supporting it and DOMMouseScroll on old
Firefox

step 1/3 for https://github.com/mootools/mootools-core/issues/2570
