### PR TITLE
Making Gruntfile test PRs only with PhantomJS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -257,18 +257,12 @@ module.exports = function(grunt) {
 		}
 
 	});
-
+	var pullRequest = process.env.TRAVIS_PULL_REQUEST;
+	var tasks = ['clean', 'packager:all', 'packager:specs'];
+	var sauceTasks = ['karma:sauce1', 'karma:sauce2', 'karma:sauce3', 'karma:sauce4', 'karma:sauce5', 'karma:sauce6'];   
+	tasks =  pullRequest != 'false' ? tasks.concat('karma:continuous') : tasks.concat(sauceTasks);
+    
 	grunt.registerTask('default', ['clean', 'packager:all', 'packager:specs', 'karma:continuous']);
 	grunt.registerTask('nocompat', ['clean', 'packager:nocompat', 'packager:specs-nocompat', 'karma:continuous']);
-	grunt.registerTask('default:travis', [
-		'clean',
-		'packager:all',
-		'packager:specs',
-		'karma:sauce1',
-		'karma:sauce2',
-		'karma:sauce3',
-		'karma:sauce4'
-		// 'karma:sauce5',
-		// 'karma:sauce6'
-	])
+	grunt.registerTask('default:travis', tasks);
 };


### PR DESCRIPTION
Because of a [limitation between SauceLabs and Travis](http://support.saucelabs.com/entries/25614798-How-can-we-set-up-an-open-source-account-that-runs-tests-on-people-s-pull-requests-) that doesn't allow credentials to be passed when it's testing a external PR

From the link:

> We've got good and not so good news for you. The not so good news first:
> As things stand right now denying forks access to secure environment variables was a conscious design choice. The problem behind this is that the travis folks want to prevent malicious behavior where one could use some sort of console.log / print statement to leak plain text user credentials to any type of service.
> We've raised this with the Travis folks and one of their devs and we are currently working on a token/HMAC based authentication method for Sauce that'll enable third parties (Pull Requests) to safely utilize the upstreams Sauce account without leaking username and access key. I unfortunately do not have an ETA on this yet. However, the solution is in the pipeline and actively being worked on.
