### PR TITLE
Use npm test, without explicitly install grunt-cli globally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,5 @@ env:
   - secure: Y3xG8HHMX3rKYqG+OmucEHXSbC2JojqLd1ZijcR2D/Ca7t09kAGpqOHBu+j8wFCj6FZOUcMLQS3f7OygTelyvNGPMlhb0Wx1OCR4Cuj4UQjkXQebHbzMn+f4JXDgXWCEgczFv4joQw9ERGFSIOxZ75jed6bO09a1q9EDMlxHPBI=
   - secure: FabKSSkcb1n1N2S9esOhD/dziZZ3RzYYzCxHqL2EUe3E6WpkjK/m6ZuCu/3e76u35s2uUqpBOoJawC/eiQiJrMhGxpFMpTNI3133wSf/iCA7LDv5G5RWxYQMtwSwjKUwM2WzV3dtUfzLbqj9H/XZT1Q/wf+/NQvFWFljG5XyktU=
 before_script:
-- npm install grunt-cli -g
 - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash
-script:
-- grunt default:travis
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MooTools is a compact, modular, Object-Oriented JavaScript framework designed for the intermediate to advanced JavaScript developer.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/grunt --verbose"
+    "test": "grunt default:travis --verbose"
   },
   "repository": {
     "type": "git",
@@ -29,6 +29,7 @@
   "homepage": "http://mootools.net",
   "devDependencies": {
     "grunt": "~0.4.2",
+    "grunt-cli": "~0.1.13",
     "grunt-mootools-packager": "^0.1.2",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-connect": "~0.7.0",


### PR DESCRIPTION
Stuff in `scripts` will have /node_modules/.bin added to the $PATH
https://www.npmjs.org/doc/misc/npm-scripts.html#path
