### PR TITLE
Removing sniffing in the test

### DIFF
--- a/Specs/Element/Element.Style.js
+++ b/Specs/Element/Element.Style.js
@@ -110,9 +110,9 @@ describe('Element.setStyles', function(){
 describe('Element.set opacity', function(){
 
 	it('should not remove existent filters on browsers with filters', function(){
-		var div = new Element('div'), 
+		var div = new Element('div'),
 		hasOpacity = document.html.style.opacity != null
-		
+
 		if (!hasOpacity && document.html.style.filter != null && !window.opera && !Syn.browser.gecko){ //we can prolly remove the last two check
 			div.style.filter = 'blur(strength=50)';
 			div.set('opacity', 0.4);
@@ -125,9 +125,6 @@ describe('Element.set opacity', function(){
 		div.set('opacity', 1e-20);
 		div.set('opacity', 0.5);
 		expect(+div.get('opacity')).toEqual(0.5);
-		if (Browser.ie && Browser.version <= 8){
-			expect(div.style.filter.split('opacity').length - 1).toEqual(1);
-		}
 	});
 
 });


### PR DESCRIPTION
The test I'm removing used some sniffing that seems to be wrong,
the test is not self-explaining, why doing 
expect(div.style.filter.split('opacity').length - 1).toEqual(1); instead of toEqual(2)? probably an indexOf would have been better, also we are testing the implementation detail and not the expectation here, 
also IE8 introduced -ms-filter so x.filter should be (x.filter||x['-ms-filter']) and should be probably feature tested 
so that we test opacity first, if not then filter.
also this is at all effect a different test and should have been in a test alone.

Removing it as I'm removing all the sniffing anyway.
