### PR TITLE
Moving obsolete code to 1.5compat

### DIFF
--- a/Source/Element/Element.Dimensions.js
+++ b/Source/Element/Element.Dimensions.js
@@ -92,10 +92,10 @@ Element.implement({
 	},
 
 	getOffsets: function(){
-    var hasGetBoundingClientRect = this.getBoundingClientRect;
-//<1.5compat>
-        hasGetBoundingClientRect = hasGetBoundingClientRect && !Browser.Platform.ios
-//</1.5compat>
+		var hasGetBoundingClientRect = this.getBoundingClientRect;
+//<1.4compat>
+		hasGetBoundingClientRect = hasGetBoundingClientRect && !Browser.Platform.ios
+//</1.4compat>
 		if (hasGetBoundingClientRect){
 			var bound = this.getBoundingClientRect(),
 				html = document.id(this.getDocument().documentElement),
@@ -115,7 +115,7 @@ Element.implement({
 		while (element && !isBody(element)){
 			position.x += element.offsetLeft;
 			position.y += element.offsetTop;
-//<1.5compat>
+//<1.4compat>
 			if (Browser.firefox){
 				if (!borderBox(element)){
 					position.x += leftBorder(element);
@@ -130,15 +130,15 @@ Element.implement({
 				position.x += leftBorder(element);
 				position.y += topBorder(element);
 			}
-//</1.5compat>
+//</1.4compat>
 			element = element.offsetParent;
 		}
-//<1.5compat>
+//<1.4compat>
 		if (Browser.firefox && !borderBox(this)){
 			position.x -= leftBorder(this);
 			position.y -= topBorder(this);
 		}
-//</1.5compat>
+//</1.4compat>
 		return position;
 	},
 


### PR DESCRIPTION
in order to move the browser sniffing to 1.5compat only, Element.Dimensions must be updated to only use getBoundingClientRect, which is used pretty much everywhere nowadays, mobile + desktop, accordingly to MDN:
https://developer.mozilla.org/en-US/docs/Web/API/Element.getBoundingClientRect
chrome 1, ff 3, ie 4, opera ?, safari 4, 
android 2, chrome android 1, mobile ff 1, ie mobile 6, opera ?, safari mobile 4.
Leaving the basic offsetParent calculation for some edge case.
