### PR TITLE
Restore karma:continuous for local testing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -216,7 +216,7 @@ module.exports = function(grunt) {
 	var tasks = travisBuild == 'compat' ? compatBuild : nocompatBuild;
 	tasks =  pullRequest != 'false' ? tasks.concat('karma:continuous') : tasks.concat('karma:sauceTask');
 
-	grunt.registerTask('default', compatBuild);
-	grunt.registerTask('nocompat', nocompatBuild);
+	grunt.registerTask('default', compatBuild.concat('karma:continuous'));
+	grunt.registerTask('nocompat', nocompatBuild.concat('karma:continuous'));
 	grunt.registerTask('default:travis', tasks);
 };


### PR DESCRIPTION
I just realized I added [a bug](f3532c4deff6b0476d71b957c903c04c8446ff89) in last matrix re-factor, so now grunt was just compiling files and not running them in any browser when testing locally. 
This PR restores the task that calls PhantomJS (or other browsers) as described in the `README.md` for local testing.
