### PR TITLE
SauceLabs browsers badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ env:
 #    - BROWSER='ie6'             BUILD='nocompat'
     
   global:
-    - secure: Y3xG8HHMX3rKYqG+OmucEHXSbC2JojqLd1ZijcR2D/Ca7t09kAGpqOHBu+j8wFCj6FZOUcMLQS3f7OygTelyvNGPMlhb0Wx1OCR4Cuj4UQjkXQebHbzMn+f4JXDgXWCEgczFv4joQw9ERGFSIOxZ75jed6bO09a1q9EDMlxHPBI=
-    - secure: FabKSSkcb1n1N2S9esOhD/dziZZ3RzYYzCxHqL2EUe3E6WpkjK/m6ZuCu/3e76u35s2uUqpBOoJawC/eiQiJrMhGxpFMpTNI3133wSf/iCA7LDv5G5RWxYQMtwSwjKUwM2WzV3dtUfzLbqj9H/XZT1Q/wf+/NQvFWFljG5XyktU=
+    - secure: myFP8vndNuVGr2b+WtP4efJ2fJL7By7PUi2yxgbUlaqK82qgkayrp7zu6G7YKYBtWRTaRvwybX4XVZn9zCvFm2xTB8xSeWy3bB63JZcYPGzLpwusgJ69Kr+K5dAn/EzIj23pIjqVic9XmEEFK1FqCLp8V2Ty4kl3RG7onfwALUo=
+    - secure: PFKH8/mY7hD82ipfa46znhWJQzEZ8226ZgHLVFLiM2LAxHP6aWGDgyYaSZVGlpulAGXx2Pq+RLPjetQRpjy7CA6NWr/2YtAxvx88QkufRRylKyNgEy5Pf1ej/V88SHnfdpGIizNeF/ofAMPmsGfBaDUm3+gU1RT+zLNj5gl3J/4=
 
 before_script:
   - curl https://gist.github.com/santiycr/5139565/raw/sauce_connect_setup.sh | bash

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,8 @@ module.exports = function(grunt) {
 
 	require('load-grunt-tasks')(grunt);
 	var browser = process.env.BROWSER;
+	var travisBuild = process.env.BUILD;
+	var pullRequest = process.env.TRAVIS_PULL_REQUEST;
 
 	grunt.initConfig({
 		'connect': {
@@ -81,8 +83,9 @@ module.exports = function(grunt) {
 				sauceLabs: {
 					username: process.env.SAUCE_USERNAME,
 					accessKey: process.env.SAUCE_ACCESS_KEY,
-					testName: 'MooTools-Core'
+					testName: 'MooTools-Core. Build: ' + travisBuild + '. Browser: ' + browser
 				},
+				reporters: ['progress', 'saucelabs'],
 				customLaunchers: {
 					chrome_linux: {
 						base: 'SauceLabs',
@@ -207,8 +210,6 @@ module.exports = function(grunt) {
 		}
 
 	});
-	var travisBuild = process.env.BUILD;
-	var pullRequest = process.env.TRAVIS_PULL_REQUEST;
 
 	var compatBuild = ['clean', 'packager:all', 'packager:specs'];
 	var nocompatBuild = ['clean', 'packager:nocompat', 'packager:specs-nocompat'];

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [![Build Status](https://travis-ci.org/mootools/mootools-core.png?branch=master)](https://travis-ci.org/mootools/mootools-core)
 
+[![Selenium Test Status](https://saucelabs.com/browser-matrix/MooTools-Core.svg)](https://saucelabs.com/u/MooTools-Core)
+
+---
+
 This repository is for MooTools developers; not users.
 All users should download MooTools from [MooTools.net](http://mootools.net/download "Download MooTools")
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "karma-requirejs": "~0.2.1",
     "karma-jasmine": "~0.1.5",
     "karma-sinon": "~1.0.2",
-    "karma-sauce-launcher": "~0.2.0",
+    "karma-sauce-launcher": "~0.2.5",
     "karma-script-launcher": "~0.1.0",
     "karma-phantomjs-launcher": "~0.1.2",
     "karma-chrome-launcher": "~0.1.2",


### PR DESCRIPTION
- add the Sauce Labs browser badge (`reporters: ['progress', 'saucelabs'],` in Gruntfile and badge in Readme)
- make the test name on Sauce more verbose `Gruntfile.js - L86`
- refactor SL credentials so we use sub-accounts, which will make possible other repos to be tested and have own badges
- update NPM version for `karma-sauce-launcher` because they had a bug in previous versions for the reporter which reports back to SL if the test passed or failed

The idea is to make it look [like this](https://github.com/SergioCrisostomo/mootools-core)
