### PR TITLE
travis.yml uses 'default' not 'compat' build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -214,7 +214,7 @@ module.exports = function(grunt) {
 	var compatBuild = ['clean', 'packager:all', 'packager:specs'];
 	var nocompatBuild = ['clean', 'packager:nocompat', 'packager:specs-nocompat'];
 
-	var tasks = travisBuild == 'compat' ? compatBuild : nocompatBuild;
+	var tasks = travisBuild == 'default' ? compatBuild : nocompatBuild;
 	tasks =  pullRequest != 'false' ? tasks.concat('karma:continuous') : tasks.concat('karma:sauceTask');
 
 	grunt.registerTask('default', compatBuild.concat('karma:continuous'));


### PR DESCRIPTION
The `travis.yml` file passes a env.variable `BUILD`, example:

```
    - BROWSER='chrome_linux'    BUILD='default'
    - BROWSER='firefox_linux'   BUILD='default'
    - BROWSER='chrome_linux'    BUILD='nocompat'
    - BROWSER='firefox_linux'   BUILD='nocompat'
```

and the gruntfile was looking for a `compat` instead of `default`.
