### PR TITLE
Correct visibility when fade is chained

### DIFF
--- a/Source/Fx/Fx.Tween.js
+++ b/Source/Fx/Fx.Tween.js
@@ -92,7 +92,7 @@ Element.implement({
 			this.setStyle('visibility', to == 0 ? 'hidden' : 'visible');
 		} else if (to != 0){
 			if (fade.$chain.length){
-				fade.chain(function (){
+				fade.chain(function(){
 					this.element.setStyle('visibility', 'visible');
 					this.callChain();
 				});
@@ -100,7 +100,7 @@ Element.implement({
 				this.setStyle('visibility', 'visible');
 			}
 		} else {
-			fade.chain(function (){
+			fade.chain(function(){
 				if (this.element.getStyle('opacity')) return;
 				this.element.setStyle('visibility', 'hidden');
 				this.callChain();

--- a/Source/Fx/Fx.Tween.js
+++ b/Source/Fx/Fx.Tween.js
@@ -87,11 +87,26 @@ Element.implement({
 		if (!toggle) this.eliminate('fade:flag');
 		fade[method].apply(fade, args);
 		var to = args[args.length - 1];
-		if (method == 'set' || to != 0) this.setStyle('visibility', to == 0 ? 'hidden' : 'visible');
-		else fade.chain(function(){
-			this.element.setStyle('visibility', 'hidden');
-			this.callChain();
-		});
+		
+		if (method == 'set'){
+			this.setStyle('visibility', to == 0 ? 'hidden' : 'visible');
+		} else if (to != 0){
+			if (fade.$chain.length){
+				fade.chain(function (){
+					this.element.setStyle('visibility', 'visible');
+					this.callChain();
+				});
+			} else {
+				this.setStyle('visibility', 'visible');
+			}
+		} else {
+			fade.chain(function (){
+				if (this.element.getStyle('opacity')) return;
+				this.element.setStyle('visibility', 'hidden');
+				this.callChain();
+			});
+		}
+
 		return this;
 	},
 

--- a/Specs/Fx/Fx.Tween.js
+++ b/Specs/Fx/Fx.Tween.js
@@ -75,6 +75,33 @@ describe('Fx.Tween', function(){
 
 	});
 
+	it('should fade out an element and fade in when triggerd inside the onComplete event', function(){
+
+		var element = new Element('div').inject($(document.body));
+		var firstOpacity, lastOpacity, lastVisibility, runOnce = true;
+		element.set('tween', {
+			duration: 100,
+			onComplete: function (){
+                if(runOnce){
+                    firstOpacity = this.element.getStyle('opacity');
+                    runOnce && this.element.fade();
+                    runOnce = false;
+                }
+                
+			}
+		});
+
+		element.fade();
+		this.clock.tick(250);
+		lastOpacity = element.getStyle('opacity');
+		lastVisibility = element.getStyle('visibility');
+
+		expect(firstOpacity.toInt()).toEqual(0);
+		expect(lastOpacity.toInt()).toEqual(1);
+		expect(lastVisibility).toEqual('visible');
+		element.destroy();
+	});
+
 	it('should fade an element with toggle', function(){
 
 		var element = new Element('div', {


### PR DESCRIPTION
fixes #2593

When a new fade is called inside the onComplete event of first fade out,
then the opacity fades as expected but the visibility will not be set back to `visible`. This happens because the first fade sets the visibility after the fade is done. So the onComplete actually fires before the visibility is set.

related/history #2074
