### PR TITLE
Remove last trace of sniffing

### DIFF
--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -45,7 +45,7 @@ var parse = function(ua, platform){
 
 var Browser = this.Browser = parse(navigator.userAgent, navigator.platform);
 
-if (Browser.ie){
+if (Browser.name == 'ie'){
 	Browser.version = document.documentMode;
 }
 


### PR DESCRIPTION
Browser.ie is deprecated, this check can be done with Browser.name
instead.

closes #2600
