### PR TITLE
Correct docs about which event is fired

### DIFF
--- a/Docs/Request/Request.JSON.md
+++ b/Docs/Request/Request.JSON.md
@@ -49,7 +49,7 @@ Fired when the parsed JSON is not valid and the secure option is set.
 
 #### failure
 
-Fired when the request failed (error status code), or when JSON string could not be parsed.
+Fired when the request failed (error status code).
 
 ##### Signature:
 


### PR DESCRIPTION
fixes #2489

In the documentation it states a `failure` event is fired when a JSON
string could not be parsed, [but the fired event is `error`](https://github.com/mootools/mootools-core/blob/master/Source/Request/Request.JSON.js#L39). 

The [documentation for`onError`](https://github.com/mootools/mootools-core/blob/master/Docs/Request/Request.JSON.md#error) already describes that `error` is fired when a JSON string could not be parsed.

> #### error
> 
> Fired when the parsed JSON is not valid and the secure option is set.
