### PR TITLE
Fixing hasClass without classList, which cannot use .contains anymore.

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -732,7 +732,7 @@ Element.implement({
 	hasClass: hasClassList ? function(className){
 		return this.classList.contains(className);
 	} : function(className){
-		return (' ' + this.className.clean() + ' ').contains(' ' + className + ' ');
+		return classes(this.className).contains(className);
 	},
 
 	addClass: hasClassList ? function(className){

--- a/Specs/Element/Element.js
+++ b/Specs/Element/Element.js
@@ -1072,10 +1072,10 @@ describe('Element.clone', function(){
 describe('Element className methods', function(){
 
 	it('should return true if the Element has the given class', function(){
-		var div = new Element('div', {'class': 'header bold'});
+		var div = new Element('div', {'class': 'header bold\tunderline'});
 		expect(div.hasClass('header')).toBeTruthy();
 		expect(div.hasClass('bold')).toBeTruthy();
-		expect(div.hasClass('random')).toBeFalsy();
+		expect(div.hasClass('underline')).toBeTruthy();
 	});
 
 	it('should return false if the element does not have the given class', function(){


### PR DESCRIPTION
String.prototype.contains is now compatible with ES6, which doesn't
support the second 'separator' argument anymore.

Thanks @mrpapercut
