### PR TITLE
Fix: ReferenceError: assignment to undeclared variable currentExpression

### DIFF
--- a/Source/Slick/Slick.Finder.js
+++ b/Source/Slick/Slick.Finder.js
@@ -568,7 +568,7 @@ local.matchNode = function(node, selector){
 	if (!parsed) return true;
 
 	// simple (single) selectors
-	var expressions = parsed.expressions, simpleExpCounter = 0, i;
+	var expressions = parsed.expressions, simpleExpCounter = 0, i, currentExpression;
 	for (i = 0; (currentExpression = expressions[i]); i++){
 		if (currentExpression.length == 1){
 			var exp = currentExpression[0];


### PR DESCRIPTION
Fix: ReferenceError: assignment to undeclared variable `currentExpression`.
