### PR TITLE
Element.Style's reference to document.body sometimes throws error

### DIFF
--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -33,7 +33,7 @@ el = null;
 //</ltIE9>
 
 var hasGetComputedStyle = !!window.getComputedStyle,
-	supportBorderRadius = document.body.style.borderRadius != null;
+	supportBorderRadius = document.createElement('div').style.borderRadius != null;
 
 Element.Properties.styles = {set: function(styles){
 	this.setStyles(styles);


### PR DESCRIPTION
The check for `supportBorderRadius` references document.body which may not
exist yet (if one includes the script in the `head` for example).

Attn: @ibolmo
