### PR TITLE
Make url available as a public attribute

### DIFF
--- a/Source/Request/Request.js
+++ b/Source/Request/Request.js
@@ -213,6 +213,7 @@ var Request = this.Request = new Class({
 			}
 		}, this);
 
+		this.url = url;
 		this.fireEvent('request');
 		xhr.send(data);
 		if (!this.options.async) this.onStateChange();
@@ -231,6 +232,7 @@ var Request = this.Request = new Class({
 		}
 		xhr.onreadystatechange = empty;
 		if (progressSupport) xhr.onprogress = xhr.onloadstart = empty;
+		this.url = undefined;
 		this.xhr = new Browser.Request();
 		this.fireEvent('cancel');
 		return this;


### PR DESCRIPTION
This is particularly useful if the real GET url is not unknown because additional parameters are appended via `send({param: 1})`. With this change you can assign the right url to `pushState`. 

``` javascript
var request = new Request.HTML({
onSuccess: function(){
    window.history.pushState({ turbolinks: true, url: request.url }, '', request.url);
}
}).send({param: 1});
```
