### PR TITLE
uglify keping license info

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -19,7 +19,7 @@ provides: [Core, MooTools, Type, typeOf, instanceOf, Native]
 
 ...
 */
-
+/*! MooTools: the javascript framework. license: MIT-style license. copyright: Copyright (c) 2006-2014 [Valerio Proietti](http://mad4milk.net/).*/
 (function(){
 
 this.MooTools = {

--- a/Tests/dist-tasks.json
+++ b/Tests/dist-tasks.json
@@ -18,7 +18,8 @@
     "uglify": {
         "options": {
             "mangle": false,
-            "compress": true
+            "compress": true,
+            "preserveComments": "some"
         },
         "dist": {
             "files": [


### PR DESCRIPTION
This is a suggestion to be able to Uglify the source still keeping the minimal license info.
