### PR TITLE
close param tag

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -679,7 +679,7 @@ var pollutesGetAttribute = (function(div){
 })(document.createElement('div'));
 
 var hasCloneBug = (function(test){
-	test.innerHTML = '<object><param name="should_fix" value="the unknown"></object>';
+	test.innerHTML = '<object><param name="should_fix" value="the unknown" /></object>';
 	return test.cloneNode(true).firstChild.childNodes.length != 1;
 })(document.createElement('div'));
 /* </ltIE9> */


### PR DESCRIPTION
close `<param>` tag to comply with XHTML

fixes #2638
