### PR TITLE
Update Element.Dimensions.js

### DIFF
--- a/Source/Element/Element.Dimensions.js
+++ b/Source/Element/Element.Dimensions.js
@@ -76,8 +76,12 @@ Element.implement({
 		// Bug info: https://bugzilla.mozilla.org/show_bug.cgi?id=530985
 		if (this.get('tag') == 'svg') return svgCalculateSize(this);
 		
-		var bounds = this.getBoundingClientRect();
-		return {x: bounds.width, y: bounds.height};
+		try {
+			var bounds = this.getBoundingClientRect();
+			return {x: bounds.width, y: bounds.height};
+		} catch(e) {
+			return {x: 0, y: 0};
+		}
 	},
 
 	getScrollSize: function(){


### PR DESCRIPTION
Fix "Unspecified Error" in Internet Explorer when calling getSize() on a node that isn't in the DOM.

cf. http://bugs.jquery.com/ticket/4996 , https://github.com/jquery/jquery/commit/cf672a2e7a886cac5ae62f6772c6b4b43b19a2fc , and https://github.com/jquery/jquery/commit/ec7ea3fba15379ebe8ddff5f6c99ec3faf8d6d17
