### PR TITLE
Protect 'contains' method in Array prototype

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -268,7 +268,7 @@ force('String', String, [
 	'slice', 'split', 'substr', 'substring', 'trim', 'toLowerCase', 'toUpperCase'
 ])('Array', Array, [
 	'pop', 'push', 'reverse', 'shift', 'sort', 'splice', 'unshift', 'concat', 'join', 'slice',
-	'indexOf', 'lastIndexOf', 'filter', 'forEach', 'every', 'map', 'some', 'reduce', 'reduceRight'
+	'indexOf', 'lastIndexOf', 'filter', 'forEach', 'every', 'map', 'some', 'reduce', 'reduceRight', 'contains'
 ])('Number', Number, [
 	'toExponential', 'toFixed', 'toLocaleString', 'toPrecision'
 ])('Function', Function, [


### PR DESCRIPTION
Firefox 35 includes support for the 'contains' method of ECMA 7. This breaks MooTools because it is not a protected method. Unfortunately a lot of sites are going to be broken by this, I've already tested a few including my own and jsfiddle. The specific error I see is that the Elements class does not implement the 'contains' method from the Array prototype. I've added this small change to my site and it fixes the problem.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/contains
