### PR TITLE
Travis Only run the phantomjs browser for pull requests, echo 0 for others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - BROWSER='ie9'             BUILD='default'
     - BROWSER='ie8'             BUILD='default'
     - BROWSER='ie7'             BUILD='default'
-#    - BROWSER='ie6'             BUILD='default'
+    - BROWSER='phantomjs'       BUILD='default'
 
     - BROWSER='chrome_linux'    BUILD='nocompat'
     - BROWSER='firefox_linux'   BUILD='nocompat'
@@ -31,7 +31,7 @@ env:
     - BROWSER='ie9'             BUILD='nocompat'
     - BROWSER='ie8'             BUILD='nocompat'
     - BROWSER='ie7'             BUILD='nocompat'
-#    - BROWSER='ie6'             BUILD='nocompat'
+    - BROWSER='phantomjs'       BUILD='nocompat'
 
   global:
     - secure: myFP8vndNuVGr2b+WtP4efJ2fJL7By7PUi2yxgbUlaqK82qgkayrp7zu6G7YKYBtWRTaRvwybX4XVZn9zCvFm2xTB8xSeWy3bB63JZcYPGzLpwusgJ69Kr+K5dAn/EzIj23pIjqVic9XmEEFK1FqCLp8V2Ty4kl3RG7onfwALUo=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
 	require('load-grunt-tasks')(grunt);
 
 	var fs = require('fs');
-	var pullRequest = process.env.TRAVIS_PULL_REQUEST;	
+	var usePhantom = process.env.TRAVIS_PULL_REQUEST != 'false' || process.env.BROWSER == 'phantomjs';
 	var distTasks = JSON.parse(fs.readFileSync('Tests/dist-tasks.json'));
 	var options = require('./Tests/gruntfile-options');
 
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
 	var compatBuild = ['clean:specs', 'packager:all', 'packager:specs'];
 	var nocompatBuild = ['clean:specs', 'packager:nocompat', 'packager:specs-nocompat'];
 	var tasks = options.travis.build == 'default' ? compatBuild : nocompatBuild;
-	tasks =  pullRequest != 'false' ? tasks.concat('karma:continuous') : tasks.concat('karma:sauceTask');
+	tasks = usePhantom ? tasks.concat('karma:continuous') : tasks.concat('karma:sauceTask');
 
 	grunt.registerTask('default', compatBuild.concat('karma:continuous'));		// local testing - compat build
 	grunt.registerTask('nocompat', nocompatBuild.concat('karma:continuous'));	// local testing - no compat build

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "MooTools is a compact, modular, Object-Oriented JavaScript framework designed for the intermediate to advanced JavaScript developer.",
   "main": "dist/mootools-core.js",
   "scripts": {
-    "test": "grunt default:travis --verbose"
+    "test": "test $TRAVIS_PULL_REQUEST != false && test $BROWSER != phantomjs || grunt default:travis --verbose"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
For pull requests, now it runs phantomjs for the entire browser matrix. With this change, it only runs the phantomjs once, and quickly exists all others.
