### PR TITLE
The browser support version is current-1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,25 @@ env:
     - BROWSER='opera_win2000'   BUILD='default'
     - BROWSER='safari7'         BUILD='default'
     - BROWSER='safari6'         BUILD='default'
-    - BROWSER='safari5_osx10_6' BUILD='default'
-    - BROWSER='safari5_win7'    BUILD='default'
     - BROWSER='ie11'            BUILD='default'
     - BROWSER='ie10'            BUILD='default'
     - BROWSER='ie9'             BUILD='default'
     - BROWSER='ie8'             BUILD='default'
     - BROWSER='ie7'             BUILD='default'
 #    - BROWSER='ie6'             BUILD='default'
-    
+
     - BROWSER='chrome_linux'    BUILD='nocompat'
     - BROWSER='firefox_linux'   BUILD='nocompat'
     - BROWSER='opera_win2000'   BUILD='nocompat'
     - BROWSER='safari7'         BUILD='nocompat'
     - BROWSER='safari6'         BUILD='nocompat'
-    - BROWSER='safari5_osx10_6' BUILD='nocompat'
-    - BROWSER='safari5_win7'    BUILD='nocompat'
     - BROWSER='ie11'            BUILD='nocompat'
     - BROWSER='ie10'            BUILD='nocompat'
     - BROWSER='ie9'             BUILD='nocompat'
     - BROWSER='ie8'             BUILD='nocompat'
     - BROWSER='ie7'             BUILD='nocompat'
 #    - BROWSER='ie6'             BUILD='nocompat'
-    
+
   global:
     - secure: myFP8vndNuVGr2b+WtP4efJ2fJL7By7PUi2yxgbUlaqK82qgkayrp7zu6G7YKYBtWRTaRvwybX4XVZn9zCvFm2xTB8xSeWy3bB63JZcYPGzLpwusgJ69Kr+K5dAn/EzIj23pIjqVic9XmEEFK1FqCLp8V2Ty4kl3RG7onfwALUo=
     - secure: PFKH8/mY7hD82ipfa46znhWJQzEZ8226ZgHLVFLiM2LAxHP6aWGDgyYaSZVGlpulAGXx2Pq+RLPjetQRpjy7CA6NWr/2YtAxvx88QkufRRylKyNgEy5Pf1ej/V88SHnfdpGIizNeF/ofAMPmsGfBaDUm3+gU1RT+zLNj5gl3J/4=


### PR DESCRIPTION
So safari 5 doesn't need to be tested anymore.

On the other hand, it doesn't do any harm. 

Also maybe we could remove some safari 5 code?
