### PR TITLE
Es7 compatible Array#contains

### DIFF
--- a/Source/Types/Array.js
+++ b/Source/Types/Array.js
@@ -94,16 +94,11 @@ Array.implement({
 		var length = this.length;
 		if (length < 1) return false;
 		var from = Math.floor((arguments[1] || 0) -0);
-
-		if (from < 0){
-			from = length + from
-		}
-		if (from === -Infinity || from < 0) from = 0
-/* in ES6 max length is 2^53-1, currently limited to 2^32-1*/
+		if (from < 0) from = length + from;
+		if (from === -Infinity || from < 0) from = 0;
+		/* in ES6 max length is 2^53-1, currently limited to 2^32-1*/
 		if (from >= length || from > 0xFFFFFFFF) return false;
-
 		var check = typeof item === 'number' && isNaN(item) ? isNaN : function(c){ return c === item };
-
 		for (var i=from; i < length; i++)
 			if (check(this[i])) return true;
 		return false;

--- a/Source/Types/Array.js
+++ b/Source/Types/Array.js
@@ -93,7 +93,7 @@ Array.implement({
 	contains: function contains(item) {
 		var length = this.length;
 		if (length < 1) return false;
-		var from = Math.floor((arguments[1] || 0) -0);
+		var from = Math.floor(arguments[1] || 0);
 		if (from < 0) from = length + from;
 		if (from === -Infinity || from < 0) from = 0;
 		/* in ES6 max length is 2^53-1, currently limited to 2^32-1*/

--- a/Source/Types/Array.js
+++ b/Source/Types/Array.js
@@ -89,11 +89,26 @@ Array.implement({
 		}
 		return result;
 	},
+	/*<!ES7>*/
+	contains: function contains(item) {
+		var length = this.length;
+		if (length < 1) return false;
+		var from = Math.floor((arguments[1] || 0) -0);
 
-	contains: function(item, from){
-		return this.indexOf(item, from) != -1;
+		if (from < 0){
+			from = length + from
+		}
+		if (from === -Infinity || from < 0) from = 0
+/* in ES6 max length is 2^53-1, currently limited to 2^32-1*/
+		if (from >= length || from > 0xFFFFFFFF) return false;
+
+		var check = typeof item === 'number' && isNaN(item) ? isNaN : function(c){ return c === item };
+
+		for (var i=from; i < length; i++)
+			if (check(this[i])) return true;
+		return false;
 	},
-
+	/*</!ES7>*/
 	append: function(array){
 		this.push.apply(this, array);
 		return this;

--- a/Specs/Types/Array.js
+++ b/Specs/Types/Array.js
@@ -414,9 +414,11 @@ describe("Array", function(){
 				it('s length should be 1', function(){
 					expect([].contains.length).toEqual(1);
 				});
-				it('s name should be "contains"', function(){
-					expect([].contains.name).toEqual('contains');
-				});
+				if(Function.prototype.name !== undefined){ //IE doesn't have that yet (I could use function serialization but cba).
+					it('s name should be "contains"', function(){
+						expect([].contains.name).toEqual('contains');
+					});
+				}
 				it('s property descriptor should be right', function(){
 					var propertyDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'contains');
 					expect(propertyDescriptor.writable).toBeTruthy();

--- a/Specs/Types/Array.js
+++ b/Specs/Types/Array.js
@@ -8,6 +8,10 @@ provides: ~
 
 (function(){
 
+var defineGetter = function(object, name, getter){
+	Object.defineProperty(object, name, {get : getter} );
+}
+
 var getTestArray = function(){
 	var a = [0, 1, 2, 3];
 	delete a[1];
@@ -137,13 +141,581 @@ describe("Array", function(){
 	});
 
 	// Array.contains
+	describe("Array.contains", function(){
+		// old MooTools Tests
+		it('should return true if the array contains the specified item', function(){
+			expect([1,2,3,0,0,0].contains(0)).toBeTruthy();
+		});
 
-	it('should return true if the array contains the specified item', function(){
-		expect([1,2,3,0,0,0].contains(0)).toBeTruthy();
-	});
+		it('should return false if the array does not contain the specified item', function(){
+			expect([0,1,2].contains('not found')).toBeFalsy();
+		});
 
-	it('should return false if the array does not contain the specified item', function(){
-		expect([0,1,2].contains('not found')).toBeFalsy();
+		//ES7 tests converted to MT, please refer to https://github.com/domenic/Array.prototype.contains/tree/master/test for original BSD license for individual tests.
+		if(Object.create && Object.defineProperty){
+			describe("sees a new element added by a getter that is hit during iteration", function(){
+				it('Expect array-like to contain "c", which was added by the getter for the 1st element', function(){
+					var arrayLike = {
+							length: 5,
+							0: 'a'
+					};
+					defineGetter(arrayLike, 1 , function(){
+							this[2] = 'c';
+							return 'b';
+					});
+
+					var result = Array.prototype.contains.call(arrayLike, 'c');
+					expect(result).toBeTruthy();
+				});
+			});
+			describe("works on array-like objects", function(){
+				var arrayLike1 = { length: 5, 0: "a", 1: "b" };
+				it('Expected array-like to contain "a"', function(){
+					var result1 = Array.prototype.contains.call(arrayLike1, "a");
+					expect(result1).toBeTruthy();
+				});
+				it('Expected array-like not to contain "c"', function(){
+					var result2 = Array.prototype.contains.call(arrayLike1, "c");
+					expect(result2).toBeFalsy();
+				});
+				var arrayLike2 = { length: 2, 0: "a", 1: "b", 2: "c" };
+				it('Expected array-like to contain "b"', function(){
+					var result3 = Array.prototype.contains.call(arrayLike2, "b");
+					expect(result3).toBeTruthy();
+				});
+				it('Expected array-like to not contain "c"', function(){
+					var result4 = Array.prototype.contains.call(arrayLike2, "c");
+					expect(result4).toBeFalsy();
+				});
+			});
+			describe('should terminate if getting an index throws an exception',  function(){
+				it('should re-throw and stop', function(){
+					var trappedZero = {
+						length: 2
+					};
+					defineGetter(trappedZero, 0 , function(){
+						throw new Error('This error should be re-thrown');
+					});
+					defineGetter(trappedZero, 1, function(){
+						throw new Error('Should not try get the element at index 1');
+					})
+
+					try{
+						Array.prototype.contains.call(trappedZero, 'a');
+					} catch(e){
+						expect(e.message).toEqual('This error should be re-thrown')
+					}
+				});
+			});
+			describe('should terminate if an exception occurs converting the fromIndex to a number', function(){
+				var fromIndex = {
+					valueOf: function () {
+						throw new Error('This error should be re-thrown');
+					}
+				};
+
+				var trappedZero = {
+				    length: 1
+				};
+				defineGetter(trappedZero, 0, function(){
+					throw new Error('Should not try get the element at index 0');
+				});
+				it('should re-throw and stop', function(){
+					try{
+						Array.prototype.contains.call(trappedZero, 'a', fromIndex);
+					} catch(e){
+						expect(e.message).toEqual('This error should be re-thrown')
+					}
+				});
+			});
+			describe('should terminate if an exception occurs getting the length', function(){
+
+				var fromIndexTrap = {
+					valueOf: function () {
+						throw new Error('Should not try to call ToInteger on valueOf');
+					}
+				}
+
+				var throwingLength = {};
+				defineGetter(throwingLength, 'length', function(){throw new Error('This error should be re-thrown');});
+				defineGetter(throwingLength, 0, function(){throw new Error('Should not try to get the zeroth element')});
+				it('should re-throw and stop', function(){
+					try{
+						Array.prototype.contains.call(throwingLength, 'a', fromIndexTrap);
+					} catch(e){
+						expect(e.message).toEqual('This error should be re-thrown');
+					}
+				});
+			});
+			describe('should terminate if an exception occurs converting the length to a number', function(){
+				var fromIndexTrap = {
+					valueOf: function () {
+						throw new Error('Should not try to call ToInteger on valueOf');
+					}
+				};
+
+				var badLength = {
+					length: {
+						valueOf: function () {
+							throw new Error('This error should be re-thrown');
+						}
+					}
+				};
+
+				defineGetter(badLength, 0, function(){throw new Error('Should not try to get the zeroth element')})
+				it('should re-throw and stop', function(){
+					try{
+						Array.prototype.contains.call(badLength, 'a', fromIndexTrap);
+					} catch(e){
+						expect(e.message).toEqual('This error should be re-thrown');
+					}
+				});
+			});
+			describe('should search the whole array, as the optional second argument fromIndex defaults to 0', function(){
+				it('should contain 10', function(){
+					expect([10, 11].contains(10)).toBeTruthy();
+				})
+				it('should contain 11', function(){
+					expect([10, 11].contains(11)).toBeTruthy();
+				})
+
+				var arrayLike = {
+					length: 2
+				};
+				defineGetter(arrayLike, 0, function(){return '1'})
+				defineGetter(arrayLike, 1, function(){return '2'})
+
+				it('should contain "1"', function(){
+					expect([].contains.call(arrayLike, '1')).toBeTruthy();
+				})
+				it('should contain "2"', function(){
+					expect([].contains.call(arrayLike, '2')).toBeTruthy();
+				})
+			})
+			describe('returns false if fromIndex is greater or equal to the length of the array', function(){
+				it('should not be searched', function(){
+					var array = [1, 2];
+					expect(array.contains(2, 3)).toBeFalsy();
+					expect(array.contains(2, 2)).toBeFalsy();
+				})
+
+				var arrayLikeWithTrap = {
+					length: 2
+				};
+				defineGetter(arrayLikeWithTrap, 0, function(){throw new Error('Getter for 0 should not be called')});
+				defineGetter(arrayLikeWithTrap, 1, function(){throw new Error('Getter for 1 should not be called')});
+
+				it('should not search arraylike', function(){
+					expect([].contains.call(arrayLikeWithTrap, 'c', 2)).toBeFalsy();
+					expect([].contains.call(arrayLikeWithTrap, 'c', 3)).toBeFalsy();
+				})
+			})
+			describe('searches the whole array if the computed index from the given negative fromIndex argument is less than 0', function(){
+				it('should search the array', function(){
+					expect([1, 3].contains(1, -4)).toBeTruthy();
+					expect([1, 3].contains(3, -4)).toBeTruthy();
+				})
+
+				var arrayLike = {
+					length: 2,
+					0: 'a'
+				};
+
+				defineGetter(arrayLike, 1, function(){return 'b'});
+				// ES7 test don't check this, I am adding it here
+				defineGetter(arrayLike, -1, function(){throw new Error('shold not try to get a negative value')});
+
+				it('should search the arrayLike', function(){
+					expect([].contains.call(arrayLike, 'a', -4)).toBeTruthy();
+					expect([].contains.call(arrayLike, 'b', -4)).toBeTruthy();
+				})
+			})
+			describe('should use a negative value as the offset from the end of the array to compute fromIndex', function(){
+				it('should find 13', function(){
+					expect([12, 13].contains(13, -1)).toBeTruthy();
+				})
+				it('should not find 12', function(){
+					expect([12, 13].contains(12, -1)).toBeFalsy();
+				})
+				it('should find 12', function(){
+					expect([12, 13].contains(12, -2)).toBeTruthy();
+				})
+
+				var arrayLike = {
+					length: 2
+				};
+				defineGetter(arrayLike, '0', function(){return 'a'})
+				defineGetter(arrayLike, '1', function(){return 'b'})
+				it('should find b', function(){
+					expect([].contains.call(arrayLike, 'b', -1)).toBeTruthy();
+				});
+				it('should not find a', function(){
+					expect([].contains.call(arrayLike, 'a', -1)).toBeFalsy();
+				});
+				it('should find a', function(){
+					expect([].contains.call(arrayLike, 'a', -2)).toBeTruthy();
+				});
+			});
+			describe('converts its fromIndex parameter to an integer', function(){
+
+				it('should not search the array', function(){
+					expect(['a', 'b'].contains('a', 2.3)).toBeFalsy();
+				});
+
+				var arrayLikeWithTraps = {
+					length: 2
+				};
+				defineGetter(arrayLikeWithTraps, 0, function(){throw new Error('Getter for index 0 should not be called')});
+				defineGetter(arrayLikeWithTraps, 1, function(){throw new Error('Getter for index 1 should not be called')});
+
+				it('Expected the array to be searched for a fromIndex fractionally above the length', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTraps, 'c', 2.1)).toBeFalsy();
+				});
+				it('Expected the array not to be searched for a fromIndex of +Infinity', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTraps, 'c', +Infinity)).toBeFalsy();
+				});
+				it('Expected the array not to be searched for a fromIndex of +Infinity', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTraps, 'c', +Infinity)).toBeFalsy();
+				});
+				it('Expected the array to be searched for a fromIndex of -Infinity', function(){
+					expect(['a', 'b', 'c'].contains('a', -Infinity)).toBeTruthy();
+				});
+				it('Expected the fromIndex to be rounded down and thus the element to be found', function(){
+					expect(['a', 'b', 'c'].contains('c', 2.9)).toBeTruthy();
+				});
+				it('Expected a fromIndex of NaN to be treated as 0 for an array', function(){
+					expect(['a', 'b', 'c'].contains('c', NaN)).toBeTruthy();
+				});
+
+				var arrayLikeWithTrapAfterZero = {
+					length: 2
+				};
+				defineGetter(arrayLikeWithTrapAfterZero, 0, function(){return 'a'});
+				defineGetter(arrayLikeWithTrapAfterZero, 1, function(){throw new Error('Getter for index 1 should not be called')});
+				it('Expected a fromIndex of NaN to be treated as 0 for an array-like', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTrapAfterZero, 'a', NaN)).toBeTruthy();
+				});
+
+				var numberLike = { valueOf: function () { return 2; } };
+				it('Expected the element not to be found with the given number-like fromIndex', function(){
+					expect(['a', 'b', 'c'].contains('a', numberLike)).toBeFalsy();
+				});
+				it('Expected the element not to be found with the given string fromIndex', function(){
+					expect(['a', 'b', 'c'].contains('a', '2')).toBeFalsy();
+				});
+				it('Expected the element to be found with the given number-like fromIndex', function(){
+					expect(['a', 'b', 'c'].contains('c', numberLike)).toBeTruthy();
+				});
+				it('Expected the element to be found with the given string fromIndex', function(){
+					expect(['a', 'b', 'c'].contains('c', '2')).toBeTruthy();
+				});
+			});
+			describe('should respect contains signature', function(){
+				it('s length should be 1', function(){
+					expect([].contains.length).toEqual(1);
+				});
+				it('s name should be "contains"', function(){
+					expect([].contains.name).toEqual('contains');
+				});
+				it('s property descriptor should be right', function(){
+					var propertyDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, 'contains');
+					expect(propertyDescriptor.writable).toBeTruthy();
+					//expect(propertyDescriptor.enumerable).toBeFalsy(); currently is enumerable.
+					expect(propertyDescriptor.configurable).toBeTruthy();
+				});
+			});
+			describe('should skip holes, and does not treat them as undefined', function(){
+				var arrayWithHoles = [,,,];
+				it('Expected array with many holes to contain undefined', function(){
+					expect(Array.prototype.contains.call(arrayWithHoles, undefined)).toBeTruthy();
+				});
+
+				var arrayWithASingleHole = ['a', 'b',, 'd'];
+				it('Expected array with a single hole to contain undefined', function(){
+					expect(arrayWithASingleHole.contains(undefined)).toBeTruthy();
+				});
+			});
+			describe('should get length property from the prototype if it is available', function(){
+				var proto = { length: 1 };
+				var arrayLike = Object.create(proto);
+				arrayLike[0] = 'a';
+
+				Object.defineProperty(arrayLike, '1', {
+					get: function () {
+						throw new Error('Getter for 1 was called');
+					}
+				});
+				it('Expected length to be determined from the prototype', function(){
+					expect(Array.prototype.contains.call(arrayLike, 'a')).toBeTruthy();
+				});
+			});
+			describe('treats a missing length property as zero', function(){
+				var arrayLikeWithTraps = {};
+				defineGetter(arrayLikeWithTraps, 0, function(){throw new Error('Getter for index 0 should not be called')})
+				defineGetter(arrayLikeWithTraps, 1, function(){throw new Error('Getter for index 1 should not be called')})
+				it('Expected a length-less object not to contain anything', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTraps, 'a')).toBeFalsy();
+				});
+			});
+			describe('should always return false on negative-length objects', function(){
+				it('Expected { length: -1 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: -1 }, 2)).toBeFalsy();
+				});
+				it('Expected { length: -2 } to not contain (no argument passed)', function(){
+					expect(Array.prototype.contains.call({ length: -2 })).toBeFalsy();
+				});
+				it('Expected { length: -Infinity } to not contain undefined', function(){
+					expect(Array.prototype.contains.call({ length: -Infinity }, undefined)).toBeFalsy();
+				});
+				it('Expected { length: -Math.pow(2, 53) } to not contain NaN', function(){
+					expect(Array.prototype.contains.call({ length: -Math.pow(2, 53) }, NaN)).toBeFalsy();
+				});
+				it('Expected { length: -1, "-1": 2 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: -1, '-1': 2 }, 2)).toBeFalsy();
+				});
+				it('Expected { length: -3, "-1": 2 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: -3, '-1': 2 }, 2)).toBeFalsy();
+				});
+				it('Expected { length: -Infinity, "-1": 2 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: -Infinity, '-1': 2 }, 2)).toBeFalsy();
+				});
+
+				var arrayLikeWithTrap = {
+					length: -1
+				};
+				defineGetter(arrayLikeWithTrap, 0, function(){throw new Error('Getter for index 0 should not be called')});
+				it('Expected trapped array-like with length -1 to not contain 2', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTrap, 2)).toBeFalsy();
+				});
+			});
+			describe('Array.prototype.contains should clamp positive lengths to 2^32 - 1', function(){
+				var fromIndexForLargeIndexTests = 9007199254740990;
+				it('Expected { length: 1 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: 1 }, 2)).toBeFalsy();
+				});
+				it('Expected { length: 1, 0: \'a\' } to contain \'a\'', function(){
+					expect(Array.prototype.contains.call({ length: 1, 0: 'a' }, 'a')).toBeTruthy();
+				});
+				it('Expected { length: +Infinity, 0: \'a\' } to contain \'a\'', function(){
+					expect(Array.prototype.contains.call({ length: +Infinity, 0: 'a' }, 'a')).toBeTruthy();
+				});
+				it('Expected { length: +Infinity } to not contain \'a\'', function(){
+					expect(Array.prototype.contains.call({ length: +Infinity }, 'a', fromIndexForLargeIndexTests)).toBeFalsy();
+				});
+
+				var arrayLikeWithTrap = {
+					length: +Infinity,
+					'9007199254740993': 'a'
+				};
+				defineGetter(arrayLikeWithTrap, 9007199254740992, function(){
+					throw('Getter for 9007199254740992 (i.e. 2^53) was called');
+				});
+				it('Expected trapped array-like with length 9007199254740992 to not contain \'a\'', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTrap, 'a', fromIndexForLargeIndexTests)).toBeFalsy();
+				});
+
+				var arrayLikeWithTooBigLength = {
+					length: 9007199254740995,
+					'9007199254740992': 'a'
+				};
+				it('Expected array-like with too-big length to not contain \'a\', since it is beyond the max length', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTooBigLength, 'a', fromIndexForLargeIndexTests)).toBeFalsy();
+				});
+			});
+			describe('should always return false on zero-length objects', function(){
+				it('Expected [] to not contain 2', function(){
+					expect([].contains(2)).toBeFalsy();
+				});
+				it('Expected [] to not contain (no argument passed)', function(){
+					expect([].contains()).toBeFalsy();
+				});
+				it('Expected [] to not contain undefined', function(){
+					expect([].contains(undefined)).toBeFalsy();
+				});
+				it('Expected [] to not contain NaN', function(){
+					expect([].contains(NaN)).toBeFalsy();
+				});
+				it('Expected { length: 0 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: 0 }, 2)).toBeFalsy();
+				});
+				it('Expected { length: 0 } to not contain (no argument passed)', function(){
+					expect(Array.prototype.contains.call({ length: 0 })).toBeFalsy();
+				});
+				it('Expected { length: 0 } to not contain undefined', function(){
+					expect(Array.prototype.contains.call({ length: 0 }, undefined)).toBeFalsy();
+				});
+				it('Expected { length: 0 } to not contain NaN', function(){
+					expect(Array.prototype.contains.call({ length: 0 }, NaN)).toBeFalsy();
+				});
+				it('Expected { length: 0, 0: 2 } to not contain 2', function(){
+					expect(Array.prototype.contains.call({ length: 0, 0: 2 }, 2)).toBeFalsy();
+				});
+				it('Expected { length: 0, 0: undefined } to not contain (no argument passed)', function(){
+					expect(Array.prototype.contains.call({ length: 0, 0: undefined })).toBeFalsy();
+				});
+				it('Expected { length: 0, 0: undefined } to not contain undefined', function(){
+					expect(Array.prototype.contains.call({ length: 0, 0: undefined }, undefined)).toBeFalsy();
+				});
+				it('Expected { length: 0, 0: NaN } to not contain NaN', function(){
+					expect(Array.prototype.contains.call({ length: 0, 0: NaN }, NaN)).toBeFalsy();
+				});
+
+				var arrayLikeWithTrap = {
+					length: 0
+				};
+				defineGetter(arrayLikeWithTrap, 0, function(){throw new Error('Getter for index 0 should not be called')});
+
+				it('Expect arraylikewithtrap to return false', function(){
+					expect(Array.prototype.contains.call(arrayLikeWithTrap)).toBeFalsy();
+				})
+
+				var trappedFromIndex = {
+					valueOf: function () {
+						throw new Error('Should not try to convert fromIndex to a number on a zero-length array');
+					}
+				};
+				it('should not try to convert from if array length is 0', function(){
+					expect([].contains('a', trappedFromIndex)).toBeFalsy();
+					expect(Array.prototype.contains.call({ length: 0 }, trappedFromIndex)).toBeFalsy();
+				});
+			});
+			describe('should not have its behavior impacted by modifications to the global property', function(){
+			var ONumber = Number;
+			function fakeNumber() {
+				throw new Error('The overriden version of fakeNumber was called!');
+			}
+
+			var global = (new Function("return this;"))();
+			global.Number = fakeNumber;
+
+			if (Number !== fakeNumber) {
+				throw new Error('Sanity check failed: could not modify the global Number');
+			}
+			it('Expected the empty array not to contain anything', function(){
+				expect([].contains('a')).toBeFalsy();
+			});
+			it('Expected the number 1 not to contain anything', function(){
+				expect(Array.prototype.contains.call(1, 'a')).toBeFalsy();
+			});
+			function fakeObject() {
+				throw new Error('The overriden version of Object was called!');
+			}
+			var OObject = Object;
+			global.Object = fakeObject;
+			if (Object !== fakeObject) {
+				throw new Error('Sanity check failed: could not modify the global Object');
+			}
+			it('Expected the empty array not to contain anything', function(){
+				expect([].contains('a')).toBeFalsy();
+			});
+			it('Expected the number 1 not to contain anything', function(){
+				expect(Array.prototype.contains.call(1, 'a')).toBeFalsy();
+			});
+			//restore
+			Object = OObject;
+			Number = ONumber;
+
+			});
+			describe('should use ToObject on this, so that when called with an object without ownProperties, it picks up numeric properties from the prototype chain', function(){
+				var test = Object.create(Object.create({
+					0: 'a',
+					1: 'b',
+					length: 2
+				}))
+				it('Expected test to contain "a"', function(){
+					expect(Array.prototype.contains.call(test, "a")).toBeTruthy();
+				});
+				it('Expected test to contain "b"', function(){
+					expect(Array.prototype.contains.call(test, "b")).toBeTruthy();
+				});
+				it('Expected test to not contain "c"', function(){
+					expect(Array.prototype.contains.call(test, "c")).toBeFalsy();
+				});
+			});
+			describe('works on objects', function(){
+				it('Did not expect the object to be found', function(){
+					expect(['a', 'b', 'c'].contains({})).toBeFalsy();
+				});
+				it('Did not expect the object to be found', function(){
+					expect([{}, {}].contains({})).toBeFalsy();
+				});
+				var obj = {};
+				it('Expected the object to be found', function(){
+					expect([obj].contains(obj)).toBeTruthy();
+				});
+				it('Did not expect the object to be found', function(){
+					expect([obj].contains(obj, 1)).toBeFalsy();
+				});
+				it('Expected the object to be found', function(){
+					expect([obj, obj].contains(obj, 1)).toBeTruthy();
+				});
+				var stringyObject = { toString: function () { return 'a'; } };
+				it('Did not expect the object to be found', function(){
+					expect(['a', 'b', obj].contains(stringyObject)).toBeFalsy();
+				});
+			});
+			describe('does not see an element removed by a getter that is hit during iteration', function(){
+				var arrayLike = {
+					length: 5,
+					0: 'a',
+					2: 'c'
+				};
+				defineGetter(arrayLike, 1, function(){
+					delete this[2];
+					return 'b';
+				});
+				it('Expected array-like to not contain "c", which was removed by the getter for the 1st element', function(){
+					expect(Array.prototype.contains.call(arrayLike, 'c')).toBeFalsy();
+				});
+			});
+			describe('should use the SameValueZero algorithm to compare', function(){
+				it('Expected [1, 2, 3] to contain 2', function(){
+					expect([1, 2, 3].contains(2)).toBeTruthy();
+				});
+				it('Expected [1, 2, 3] to not contain 4', function(){
+					expect([1, 2, 3].contains(4)).toBeFalsy();
+				});
+				it('Expected [1, 2, NaN] to contain NaN', function(){
+					expect([1, 2, NaN].contains(NaN)).toBeTruthy();
+				});
+				it('Expected [1, 2, -0] to contain +0', function(){
+					expect([1, 2, -0].contains(+0)).toBeTruthy();
+				});
+				it('Expected [1, 2, -0] to contain -0', function(){
+					expect([1, 2, -0].contains(-0)).toBeTruthy();
+				});
+				it('Expected [1, 2, +0] to contain -0', function(){
+					expect([1, 2, +0].contains(-0)).toBeTruthy();
+				});
+				it('Expected [1, 2, +0] to contain +0', function(){
+					expect([1, 2, +0].contains(+0)).toBeTruthy();
+				});
+				it('Expected [1, 2, -Infinity] to not contain +Infinity', function(){
+					expect([1, 2, -Infinity].contains(+Infinity)).toBeFalsy();
+				});
+				it('Expected [1, 2, -Infinity] to contain -Infinity', function(){
+					expect([1, 2, -Infinity].contains(-Infinity)).toBeTruthy();
+				});
+				it('Expected [1, 2, +Infinity] to not contain -Infinity', function(){
+					expect([1, 2, +Infinity].contains(-Infinity)).toBeFalsy();
+				});
+				it('Expected [1, 2, +Infinity] to contain +Infinity', function(){
+					expect([1, 2, +Infinity].contains(+Infinity)).toBeTruthy();
+				});
+			});
+			describe('stops once it hits the length of an array-like, even if there are more after', function(){
+				var arrayLike = {
+					length: 2,
+					0: 'a',
+					1: 'b'
+				};
+				defineGetter(arrayLike, 2, function(){throw new Error('Should not try to get the second element');});
+				it('Expected array-like to not contain "c"', function(){
+					expect(Array.prototype.contains.call(arrayLike, 'c')).toBeFalsy();
+				});
+			});
+		}
+
 	});
 
 	// Array.associate

--- a/Specs/Types/Array.js
+++ b/Specs/Types/Array.js
@@ -424,7 +424,7 @@ describe("Array", function(){
 					expect(propertyDescriptor.configurable).toBeTruthy();
 				});
 			});
-			describe('should skip holes, and does not treat them as undefined', function(){
+			describe('should not skip holes, and does treat them as undefined', function(){
 				var arrayWithHoles = [,,,];
 				it('Expected array with many holes to contain undefined', function(){
 					expect(Array.prototype.contains.call(arrayWithHoles, undefined)).toBeTruthy();


### PR DESCRIPTION
Change Array#contains implementation to be compatible with ES7, passes almost all the tests
I had to change one because otherwise it would have break other tests as it was tinkering with the Number.prototype (I just made it more generical, it passes it anyway).

I left out 2 tests which this implementation passes but cannot be tested as they require Symbol to be implemented in the browsers

Also it doesn't pass the enumerability test as implement and extends should be updated to use Object.defineProperty in order to pass that.

I don't think we need to force back the old implementation for compat as it cover the old behaviour with the single exception that it can find NaN as well.