### PR TITLE
Patch for Firefox - mouseenter/leave

### DIFF
--- a/Docs/Element/Element.md
+++ b/Docs/Element/Element.md
@@ -1255,7 +1255,7 @@ Empties an Element of all its children.
 	
 ### Note:
 
-This method does not garbage college the children. Use [Element:destroy][] instead.
+This method does not garbage collect the children. Use [Element:destroy][] instead.
 
 
 

--- a/Docs/Types/String.md
+++ b/Docs/Types/String.md
@@ -385,7 +385,12 @@ Strips the String of its *<script>* tags and anything in between them.
 
 ### Arguments:
 
-1. evaluate - (*boolean*, optional) If true is passed, the scripts within the String will be evaluated.
+1. evaluate - (*boolean* or *function*, optional) If true is passed, the scripts within the String will be evaluated. All external scripts are loaded synchronously & executed. If "evaluate" is a function, it is called back with the following arguments:
+
+* (*string*) - JavaScript Code between <script> and </script> tags.
+* (*string*) - The stripped text.
+* (*array*) - Array of urls of external JavaScript files (if any).
+* (*function*) - Callback function that executes all stripped JavaScript (inline + external) synchronously.
 
 ### Returns:
 
@@ -396,6 +401,18 @@ Strips the String of its *<script>* tags and anything in between them.
 	var myString = "<script>alert('Hello')</script>Hello, World.";
 	myString.stripScripts(); // returns 'Hello, World.'
 	myString.stripScripts(true); // alerts 'Hello', then returns 'Hello, World.'
+	
+	var html = '<div id="placeholder"></div>' +
+					'<script src="https://rawgithub.com/mootools/mootools-more/master/Source/More/More.js"></script>' +
+					'<script>document.id("placeholder").set("text", "Hello, world")</script>';
+	html.stripScripts(function(code, html, urls, exec){
+		// inject the stripped HTML
+		document.body.innerHTML = html;
+		// execute all JavaScript
+		exec(function(){
+			alert('All scripts loaded and executed!');
+		});
+	});
 
 
 

--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -57,65 +57,65 @@ var patched_buttons = []; // needed for a Firefox patch - see below
 			this.addListener(realType, defn, arguments[2]);
 		}
 		events[type].values.push(defn);
-      /**
-       * Patch for Firefox - firing mouseenter and mouseleave events of elements inside <button>
-       *
-       * Firefox, as well as other browsers except IE, does not have a native support
-       * for mouseenter/mouseleave events, so MooTools does some custom implementation.
-       *
-       * But when we add these events to an element which is nested inside a <button>,
-       * they are not fired
-      **/
-      if (Browser.name == 'firefox' && ['mouseenter', 'mouseleave'].contains(type)){
-         // check if the element is nested in a <button>
-         var button = (function(elem){
-            // search DOM tree above up to `limit` elements
-            var limit = 20;
-            do {
-              elem = elem.parentNode; 
-            } while (elem && elem.tagName !== 'BUTTON' && --limit);
-            return limit ? document.id(elem) : null;
-         })(this);
-         if (button && !button.retrieve('ff:patchedelements', []).contains(this)){
-            // this element is descendant of a <button> and is not yet patched
-            if (!patched_buttons.contains(button)){
-               patched_buttons.push(button); // mark the button as patched
-               // add handlers to <button>
-               button.addEvents({
-                  // onmousemove: check if the cursor is over each patched element
-                  mousemove: function(e) {
-                     this.retrieve('ff:patchedelements').each(function(el){
-                        var coords = el.getCoordinates();
-                        if (
-                           coords.left <= e.page.x && coords.right   >= e.page.x &&
-                           coords.top  <= e.page.y && coords.bottom  >= e.page.y
-                        ){
-                           if (!el.retrieve('ff:mouseenter')){
-                              // make sure we fire onmouseenter only once
-                              el.store('ff:mouseenter', true);
-                              el.fireEvent('mouseenter', [new DOMEvent({type:'mouseenter',target:el})]);
-                           }
-                        } else if (el.retrieve('ff:mouseenter')){
-                           // make sure we fire onmouseleave only once
-                           el.store('ff:mouseenter', false);
-                           el.fireEvent('mouseleave', [new DOMEvent({type:'mouseleave',target:el})]);
-                        }
-                     });
-                  },
-                  // onmouseleave: just in case check if we need to fire onmouseleave over patched elements
-                  mouseleave: function(e){
-                     this.retrieve('ff:patchedelements').each(function(el){
-                        if (el.retrieve('ff:mouseenter')){
-                           el.store('ff:mouseenter', false);
-                           el.fireEvent('mouseleave', [new DOMEvent({type:'mouseleave',target:el})]);
-                        }
-                     });
-                  }
-               });
-            }
-            button.retrieve('ff:patchedelements').push(this);
-         }
-      }
+		/**
+		 * Patch for Firefox - firing mouseenter and mouseleave events of elements inside <button>
+		 *
+		 * Firefox, as well as other browsers except IE, does not have a native support
+		 * for mouseenter/mouseleave events, so MooTools does some custom implementation.
+		 *
+		 * But when we add these events to an element which is nested inside a <button>,
+		 * they are not fired
+		**/
+		if (Browser.name == 'firefox' && ['mouseenter', 'mouseleave'].contains(type)){
+			// check if the element is nested in a <button>
+			var button = (function(elem){
+				// search DOM tree above up to `limit` elements
+				var limit = 20;
+				do {
+				  elem = elem.parentNode; 
+				} while (elem && elem.tagName !== 'BUTTON' && --limit);
+				return limit ? document.id(elem) : null;
+			})(this);
+			if (button && !button.retrieve('ff:patchedelements', []).contains(this)){
+				// this element is descendant of a <button> and is not yet patched
+				if (!patched_buttons.contains(button)){
+					patched_buttons.push(button); // mark the button as patched
+					// add handlers to <button>
+					button.addEvents({
+						// onmousemove: check if the cursor is over each patched element
+						mousemove: function(e) {
+							this.retrieve('ff:patchedelements').each(function(el){
+								var coords = el.getCoordinates();
+								if (
+									coords.left <= e.page.x && coords.right   >= e.page.x &&
+									coords.top  <= e.page.y && coords.bottom  >= e.page.y
+								){
+									if (!el.retrieve('ff:mouseenter')){
+										// make sure we fire onmouseenter only once
+										el.store('ff:mouseenter', true);
+										el.fireEvent('mouseenter', [new DOMEvent({type:'mouseenter',target:el})]);
+									}
+								} else if (el.retrieve('ff:mouseenter')){
+									// make sure we fire onmouseleave only once
+									el.store('ff:mouseenter', false);
+									el.fireEvent('mouseleave', [new DOMEvent({type:'mouseleave',target:el})]);
+								}
+							});
+						},
+						// onmouseleave: just in case check if we need to fire onmouseleave over patched elements
+						mouseleave: function(e){
+							this.retrieve('ff:patchedelements').each(function(el){
+								if (el.retrieve('ff:mouseenter')){
+									el.store('ff:mouseenter', false);
+									el.fireEvent('mouseleave', [new DOMEvent({type:'mouseleave',target:el})]);
+								}
+							});
+						}
+					});
+				}
+				button.retrieve('ff:patchedelements').push(this);
+			}
+		}
 		return this;
 	},
 

--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -20,6 +20,8 @@ Element.Properties.events = {set: function(events){
 	this.addEvents(events);
 }};
 
+var patched_buttons = []; // needed for a Firefox patch - see below
+
 [Element, Window, Document].invoke('implement', {
 
 	addEvent: function(type, fn){
@@ -55,6 +57,65 @@ Element.Properties.events = {set: function(events){
 			this.addListener(realType, defn, arguments[2]);
 		}
 		events[type].values.push(defn);
+      /**
+       * Patch for Firefox - firing mouseenter and mouseleave events of elements inside <button>
+       *
+       * Firefox, as well as other browsers except IE, does not have a native support
+       * for mouseenter/mouseleave events, so MooTools does some custom implementation.
+       *
+       * But when we add these events to an element which is nested inside a <button>,
+       * they are not fired
+      **/
+      if (Browser.name == 'firefox' && ['mouseenter', 'mouseleave'].contains(type)){
+         // check if the element is nested in a <button>
+         var button = (function(elem){
+            // search DOM tree above up to `limit` elements
+            var limit = 20;
+            do {
+              elem = elem.parentNode; 
+            } while (elem && elem.tagName !== 'BUTTON' && --limit);
+            return limit ? document.id(elem) : null;
+         })(this);
+         if (button && !button.retrieve('ff:patchedelements', []).contains(this)){
+            // this element is descendant of a <button> and is not yet patched
+            if (!patched_buttons.contains(button)){
+               patched_buttons.push(button); // mark the button as patched
+               // add handlers to <button>
+               button.addEvents({
+                  // onmousemove: check if the cursor is over each patched element
+                  mousemove: function(e) {
+                     this.retrieve('ff:patchedelements').each(function(el){
+                        var coords = el.getCoordinates();
+                        if (
+                           coords.left <= e.page.x && coords.right   >= e.page.x &&
+                           coords.top  <= e.page.y && coords.bottom  >= e.page.y
+                        ){
+                           if (!el.retrieve('ff:mouseenter')){
+                              // make sure we fire onmouseenter only once
+                              el.store('ff:mouseenter', true);
+                              el.fireEvent('mouseenter', [new DOMEvent({type:'mouseenter',target:el})]);
+                           }
+                        } else if (el.retrieve('ff:mouseenter')){
+                           // make sure we fire onmouseleave only once
+                           el.store('ff:mouseenter', false);
+                           el.fireEvent('mouseleave', [new DOMEvent({type:'mouseleave',target:el})]);
+                        }
+                     });
+                  },
+                  // onmouseleave: just in case check if we need to fire onmouseleave over patched elements
+                  mouseleave: function(e){
+                     this.retrieve('ff:patchedelements').each(function(el){
+                        if (el.retrieve('ff:mouseenter')){
+                           el.store('ff:mouseenter', false);
+                           el.fireEvent('mouseleave', [new DOMEvent({type:'mouseleave',target:el})]);
+                        }
+                     });
+                  }
+               });
+            }
+            button.retrieve('ff:patchedelements').push(this);
+         }
+      }
 		return this;
 	},
 

--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -57,15 +57,8 @@ var patched_buttons = []; // needed for a Firefox patch - see below
 			this.addListener(realType, defn, arguments[2]);
 		}
 		events[type].values.push(defn);
-		/**
-		 * Patch for Firefox - firing mouseenter and mouseleave events of elements inside <button>
-		 *
-		 * Firefox, as well as other browsers except IE, does not have a native support
-		 * for mouseenter/mouseleave events, so MooTools does some custom implementation.
-		 *
-		 * But when we add these events to an element which is nested inside a <button>,
-		 * they are not fired
-		**/
+		// Patch for Firefox - firing mouseenter and mouseleave events of elements
+		// nested inside <button>.
 		if (Browser.name == 'firefox' && ['mouseenter', 'mouseleave'].contains(type)){
 			// check if the element is nested in a <button>
 			var button = (function(elem){

--- a/Specs/Browser/Browser.js
+++ b/Specs/Browser/Browser.js
@@ -45,10 +45,32 @@ describe('String.stripScripts', function(){
 	it('should execute the stripped tags from the string', function(){
 		expect('<div><script type="text/javascript"> var stripScriptsSpec = 42; </script></div>'.stripScripts(true)).toEqual('<div></div>');
 		expect(window.stripScriptsSpec).toEqual(42);
-		expect('<div><script>\n// <!--\nvar stripScriptsSpec = 24;\n//-->\n</script></div>'.stripScripts(true)).toEqual('<div></div>');
+		expect('<div><script id="my-script">\n// <!--\nvar stripScriptsSpec = 24;\n//-->\n</script></div>'.stripScripts(true)).toEqual('<div></div>');
 		expect(window.stripScriptsSpec).toEqual(24);
 		expect('<div><script>\n/*<![CDATA[*/\nvar stripScriptsSpec = 4242;\n/*]]>*/</script></div>'.stripScripts(true)).toEqual('<div></div>');
 		expect(window.stripScriptsSpec).toEqual(4242);
+	});
+	
+	it('should load & execute script files synchronously', function(){
+		var div = new Element('div').inject(document.body);
+		[
+			'<div id="my-container"></div>',
+			'<script>',
+			'document.id("my-container").set("text", "dynamic content");',
+			'</script>',
+			'<script id="mt-more-More">',
+			'Drag = undefined;',
+			'</script>',
+			'<script type="text/javascript" id="mt-more-Drag" src="https://rawgithub.com/mootools/mootools-more/master/Source/Drag/Drag.js"></script>',
+			'<script src="https://rawgithub.com/mootools/mootools-more/master/Source/Drag/Drag.Move.js" id="mt-more-Drag-Move" type="text/javascript"></script>',
+			'<script>',
+			'new Drag.Move(div);',
+			'</script>'
+		].join('').stripScripts(function(code, html, urls, fn){
+			div.set('html', html);
+			fn();
+			expect(div.get('text')).toEqual('dynamic content');
+		});
 	});
 
 });

--- a/Tests/Element/Element.Event.mouseenter.html
+++ b/Tests/Element/Element.Event.mouseenter.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+
+		<title>Element Mouseenter Event</title>
+
+		<script src="../../Source/Core/Core.js" type="text/javascript"></script>
+		<script src="../../Source/Types/Array.js" type="text/javascript"></script>
+		<script src="../../Source/Types/Function.js" type="text/javascript"></script>
+		<script src="../../Source/Types/Number.js" type="text/javascript"></script>
+		<script src="../../Source/Types/String.js" type="text/javascript"></script>
+		<script src="../../Source/Types/Object.js" type="text/javascript"></script>
+		<script src="../../Source/Types/DOMEvent.js" type="text/javascript"></script>
+		<script src="../../Source/Browser/Browser.js" type="text/javascript"></script>
+		<script src="../../Source/Slick/Slick.Parser.js" type="text/javascript"></script>
+		<script src="../../Source/Slick/Slick.Finder.js" type="text/javascript"></script>
+		<script src="../../Source/Element/Element.js" type="text/javascript"></script>
+		<script src="../../Source/Element/Element.Event.js" type="text/javascript"></script>
+		<script src="../../Source/Element/Element.Style.js" type="text/javascript"></script>
+		<script src="../../Source/Element/Element.Dimensions.js" type="text/javascript"></script>
+
+		<style>
+
+			body {
+				font: 13px sans-serif;
+			}
+			h1 {
+			   color: white;
+			   background: red;
+			}
+
+		</style>
+
+	</head>
+	<body>
+
+		<button>
+			<h1>Mouse-enter me</h1>
+		</button>
+		<button>
+			<h1>Mouse-enter me</h1>
+		</button>
+		<button>
+			<h1>Mouse-enter me</h1>
+		</button>
+		
+		<script type="text/javascript">
+		document.body.getElements('h1').addEvents({
+			mouseenter: function(e){
+				e.target.style.color = 'yellow';
+				this.style.background = 'green';
+			},
+			mouseleave: function(e){
+				this.style.color = '';
+				e.target.style.background = '';
+			}
+		})
+		</script>
+
+	</body>
+</html>
+


### PR DESCRIPTION
Manually fire mouseenter/mouseleave events of elements nested in a <button> Fix #2662