### PR TITLE
better test of HttpOnly that does not rely on the browser supporting it

### DIFF
--- a/Specs/Utilities/Cookie.js
+++ b/Specs/Utilities/Cookie.js
@@ -29,11 +29,14 @@ describe('Cookie', function(){
 	});
 
 	it('should set HttpCookie flag correctly', function(){
-		Cookie.write('http-key', 'value', {
-			httpOnly: true
-		});
+		var instance = new Cookie('key', {
+			httpOnly: true,
+			document: {
+				cookie: ''
+			}
+		}).write('value');
 
-		expect(Cookie.read('http-key')).toBeNull();
+		expect(instance.options.document.cookie.indexOf('HttpOnly')).not.toBe(-1);
 	});
 
 });


### PR DESCRIPTION
fixes broken tests in opera for HttpOnly cookies. see #2664 
