### PR TITLE
stripScripts now loads & executes external files

### DIFF
--- a/Docs/Types/String.md
+++ b/Docs/Types/String.md
@@ -385,7 +385,12 @@ Strips the String of its *<script>* tags and anything in between them.
 
 ### Arguments:
 
-1. evaluate - (*boolean*, optional) If true is passed, the scripts within the String will be evaluated.
+1. evaluate - (*boolean* or *function*, optional) If true is passed, the scripts within the String will be evaluated. All external scripts are loaded synchronously & executed. If "evaluate" is a function, it is called back with the following arguments:
+
+* (*string*) - JavaScript Code between <script> and </script> tags.
+* (*string*) - The stripped text.
+* (*array*) - Array of urls of external JavaScript files (if any).
+* (*function*) - Callback function that executes all stripped JavaScript (inline + external) synchronously.
 
 ### Returns:
 
@@ -396,6 +401,18 @@ Strips the String of its *<script>* tags and anything in between them.
 	var myString = "<script>alert('Hello')</script>Hello, World.";
 	myString.stripScripts(); // returns 'Hello, World.'
 	myString.stripScripts(true); // alerts 'Hello', then returns 'Hello, World.'
+	
+	var html = '<div id="placeholder"></div>' +
+					'<script src="https://rawgithub.com/mootools/mootools-more/master/Source/More/More.js"></script>' +
+					'<script>document.id("placeholder").set("text", "Hello, world")</script>';
+	html.stripScripts(function(code, html, urls, exec){
+		// inject the stripped HTML
+		document.body.innerHTML = html;
+		// execute all JavaScript
+		exec(function(){
+			alert('All scripts loaded and executed!');
+		});
+	});
 
 
 

--- a/Specs/Browser/Browser.js
+++ b/Specs/Browser/Browser.js
@@ -45,10 +45,32 @@ describe('String.stripScripts', function(){
 	it('should execute the stripped tags from the string', function(){
 		expect('<div><script type="text/javascript"> var stripScriptsSpec = 42; </script></div>'.stripScripts(true)).toEqual('<div></div>');
 		expect(window.stripScriptsSpec).toEqual(42);
-		expect('<div><script>\n// <!--\nvar stripScriptsSpec = 24;\n//-->\n</script></div>'.stripScripts(true)).toEqual('<div></div>');
+		expect('<div><script id="my-script">\n// <!--\nvar stripScriptsSpec = 24;\n//-->\n</script></div>'.stripScripts(true)).toEqual('<div></div>');
 		expect(window.stripScriptsSpec).toEqual(24);
 		expect('<div><script>\n/*<![CDATA[*/\nvar stripScriptsSpec = 4242;\n/*]]>*/</script></div>'.stripScripts(true)).toEqual('<div></div>');
 		expect(window.stripScriptsSpec).toEqual(4242);
+	});
+	
+	it('should load & execute script files synchronously', function(){
+		var div = new Element('div').inject(document.body);
+		[
+			'<div id="my-container"></div>',
+			'<script>',
+			'document.id("my-container").set("text", "dynamic content");',
+			'</script>',
+			'<script id="mt-more-More">',
+			'Drag = undefined;',
+			'</script>',
+			'<script type="text/javascript" id="mt-more-Drag" src="https://rawgithub.com/mootools/mootools-more/master/Source/Drag/Drag.js"></script>',
+			'<script src="https://rawgithub.com/mootools/mootools-more/master/Source/Drag/Drag.Move.js" id="mt-more-Drag-Move" type="text/javascript"></script>',
+			'<script>',
+			'new Drag.Move(div);',
+			'</script>'
+		].join('').stripScripts(function(code, html, urls, fn){
+			div.set('html', html);
+			fn();
+			expect(div.get('text')).toEqual('dynamic content');
+		});
 	});
 
 });


### PR DESCRIPTION
Small change to `String.stripScripts` with major improvement - it also injects & executes external JS files. All JavaScript is executed synchronously, in order to preserve dependency. 

Two new arguments are passed to the `exec` function:
   - urls `Array` external files list
   - exec `Function` call this function to execute the JavaScript; accepts a callback function which is called on success

Changes are backward-compatible.