### PR TITLE
fix code-block typo

### DIFF
--- a/Docs/Types/String.md
+++ b/Docs/Types/String.md
@@ -377,7 +377,7 @@ Removes undefined keywords and ignores escaped keywords.
 String method: stripScripts {#String:stripScripts}
 ----------------------------------------------------
 
-Strips the String of its *<script>* tags and anything in between them.
+Strips the String of its `<script>` tags and anything in between them.
 
 ### Syntax:
 


### PR DESCRIPTION
Make `<string>` a code block. The `.md` is/was parsing wrong ([link](http://mootools.net/core/docs/1.5.1/Types/String#String:stripScripts)).