### PR TITLE
add pageshow and pagehide

### DIFF
--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -138,7 +138,7 @@ Element.NativeEvents = {
 	gesturestart: 2, gesturechange: 2, gestureend: 2, // gesture
 	focus: 2, blur: 2, change: 2, reset: 2, select: 2, submit: 2, paste: 2, input: 2, //form elements
 	load: 2, unload: 1, beforeunload: 2, resize: 1, move: 1, DOMContentLoaded: 1, readystatechange: 1, //window
-	hashchange: 1, popstate: 2, // history
+	hashchange: 1, popstate: 2, pageshow: 2, pagehide: 2, // history
 	error: 1, abort: 1, scroll: 1, message: 2 //misc
 };
 


### PR DESCRIPTION
fixes #2684

We could also add

```
if (type == 'pageshow' || type == 'pagehide'){
    this.persisted = event.persisted;
}
```

[in DOMEvent.js](https://github.com/mootools/mootools-core/blob/master/Source/Types/DOMEvent.js#L84), but since the original event is always accessible in `e.event` maybe no need?
