### PR TITLE
Prevent warning for input[type="email"]

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -655,6 +655,7 @@ volatileInputValue = input.value != 't';
 
 // #2443 - IE throws "Invalid Argument" when trying to use html5 input types
 try {
+	input.value = '';
 	input.type = 'email';
 	html5InputSupport = input.type == 'email';
 } catch(e){}


### PR DESCRIPTION
Browser no longer says "The specified value 't' is not a valid email address." in the console.
