### PR TITLE
Fixes #2715 - Adding Microsoft Edge UA string support to Browser.

### DIFF
--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -23,7 +23,12 @@ var parse = function(ua, platform){
 	ua = ua.toLowerCase();
 	platform = (platform ? platform.toLowerCase() : '');
 
-	var UA = ua.match(/(opera|ie|firefox|chrome|trident|crios|version)[\s\/:]([\w\d\.]+)?.*?(safari|(?:rv[\s\/:]|version[\s\/:])([\w\d\.]+)|$)/) || [null, 'unknown', 0];
+	// chrome is included in the edge UA, so need to check for edge first,
+	// before checking if it's chrome.
+	var UA = ua.match(/(edge)[\s\/:]([\w\d\.]+)/);
+	if (!UA){
+		UA = ua.match(/(opera|ie|firefox|chrome|trident|crios|version)[\s\/:]([\w\d\.]+)?.*?(safari|(?:rv[\s\/:]|version[\s\/:])([\w\d\.]+)|$)/) || [null, 'unknown', 0];
+	}
 
 	if (UA[1] == 'trident'){
 		UA[1] = 'ie';
@@ -32,7 +37,7 @@ var parse = function(ua, platform){
 		UA[1] = 'chrome';
 	}
 
-	platform = ua.match(/ip(?:ad|od|hone)/) ? 'ios' : (ua.match(/(?:webos|android)/) || platform.match(/mac|win|linux/) || ['other'])[0];
+	platform = ua.match(/ip(?:ad|od|hone)/) ? 'ios' : (ua.match(/(?:webos|android)/) || ua.match(/mac|win|linux/) || ['other'])[0];
 	if (platform == 'win') platform = 'windows';
 
 	return {

--- a/Specs/Browser/Browser.js
+++ b/Specs/Browser/Browser.js
@@ -228,6 +228,15 @@ describe('Browser.parseUA', function(){
 				name: 'chrome',
 				version: 33
 			}
+		},
+		edge12: {
+			desc: 'Edge 12',
+			string: 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0',
+			expect: {
+				name: 'edge',
+				version: 12,
+				platform: 'windows'
+			}
 		}
 	};
 
@@ -235,12 +244,12 @@ describe('Browser.parseUA', function(){
 		return function(){
 			var browser = parse(ua.string, '');
 			Object.forEach(ua.expect, runExpects, browser);
-		}
-	}
+		};
+	};
 
 	var runExpects = function(val, key){
 		expect(this[key]).toEqual(val);
-	}
+	};
 
 	Object.forEach(userAgents, function(obj){
 		it('should parse ' + obj.desc + ' user agent string', testUA(obj));


### PR DESCRIPTION
Fixes #2715 

The UA string looks like:

```
Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0
```

Also fixes platform recognition, where the wrong variable was matched,
so it did not recognize windows/linux/mac, but identified it as 'other'.
