### PR TITLE
add Function.debounce

### DIFF
--- a/Docs/Types/Function.md
+++ b/Docs/Types/Function.md
@@ -368,6 +368,56 @@ Executes a function in the specified intervals of time. Periodic execution can b
 
 - [MDN setInterval][], [MDN clearInterval][]
 
+Function: Function.debounce {#Function:Function-debounce}
+---------------------------------------------------------
+
+This method will return a new function that will be called only once per group of close calls. After a defined delay it will be able to be called again.
+
+### Syntax:
+
+	var debounceFn = myFn.debounce({delay: 100});
+
+### Arguments:
+
+1. obj - (*mixed*) If this argument is a number it will use it as the *delay* timeout of the debounce. If this argument is a object it will allow more specific configuration. Leaving the argument empty will fall to default values.
+
+### Returns:
+
+* (*function*) A debounce function that will be called only once per group of close function calls.
+
+### Examples:
+
+	// get scroll position after scroll has stopped
+	var getNewScrollPosition = function () {
+		var scroll = window.getScroll();
+		alert(scroll.y);
+	}
+	window.addEvent('scroll', getNewScrollPosition.debounce(500));
+
+	// send a Request to server with data from a search field
+	// 500ms after you stopped typing, to avoid one request per character
+	var input = document.getElement('input');
+	var request = new Request({
+		url: 'your.url',
+		onSuccess: function(response) {
+			$('res').set('html', response);
+		}
+	});
+
+	function fn(){
+		request.send({data: {value: this.value}});   
+	}
+
+	input.addEventListener('keyup', fn.debounce(500));
+
+
+### Options:
+
+* *delay* - The delay after which the debounce function is called. Defaults to 250ms.
+* *when* - When to fire the debounce call. Can be at beginning of group call (*early*), at end (*late*) or *both*. Defaults to *late*.
+* *once* - If *true* will call the function only once per event handler. Defaults to *false*.
+
+
 
 Deprecated Functions {#Deprecated-Functions}
 ============================================

--- a/Source/Types/Function.js
+++ b/Source/Types/Function.js
@@ -72,6 +72,31 @@ Function.implement({
 
 	periodical: function(periodical, bind, args){
 		return setInterval(this.pass((args == null ? [] : args), bind), periodical);
+	},
+
+	debounce: function(opts){
+		var timeout,
+			fn = this,
+			fireOnce = 0;
+		if (typeof opts == 'number') opts = {delay: opts};
+		else opts = opts || {};
+		if (!opts.delay) opts.delay = 250;
+
+		return function(){
+			if (fireOnce == 2 && opts.when == 'both' || fireOnce && opts.when != 'both') return;
+			var self = this,
+				args = arguments,
+				callNow = !timeout && (opts.when == 'early' || opts.when == 'both');
+			var later = function(){
+				if (opts.when != 'early') fn.apply(self, args);
+				timeout = null;
+				if (opts.once) fireOnce = 2;
+			};
+			clearTimeout(timeout);
+			timeout = setTimeout(later, opts.delay);
+			if (callNow) fn.apply(self, args);
+			if (opts.once && callNow) fireOnce = 1;
+		};
 	}
 
 });

--- a/Specs/Types/Function.js
+++ b/Specs/Types/Function.js
@@ -244,7 +244,7 @@ describe('Function.bind', function(){
 	});
 
 	dit('should still be possible to use it as constructor', function(){
-		function Alien(type) {
+		function Alien(type){
 			this.type = type;
 		}
 
@@ -428,6 +428,235 @@ describe('Function.periodical', function(){
 
 		expect(argumentCount).toEqual(0);
 		clearInterval(timer);
+	});
+
+});
+
+describe('Debounce', function(){
+	var fn, debounceFn, caller, counter = 0,
+		debounceCalls = 0;
+		var sum = 0;
+
+	function startCaller(){
+		caller = setInterval(function(){
+			if (debounceFn){
+				counter++;
+				debounceFn();
+			}
+		}, 10);
+	}
+	beforeEach(function(){
+		fn = function(){
+			debounceCalls++;
+		};
+		startCaller();
+	});
+
+	afterEach(function(){
+		expect(counter > 40).toBeTruthy(); // control spec
+		fn = debounceFn = caller = null;
+		counter = debounceCalls = 0;
+		clearInterval(caller);
+	});
+
+	it('should debounce as default', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce();
+		waitsFor(function(){
+			if (counter > 40){
+				clearInterval(caller);
+				expect(debounceCalls == 0).toBeTruthy();
+				return true;
+			}
+		}, 'enough calls to happen', 1000);
+		waits(300);
+		runs(function(){
+			expect(debounceCalls == 1).toBeTruthy();
+		});
+	});
+
+	it('should debounce early', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce({
+			when: 'early',
+			delay: 150
+		});
+		waitsFor(function(){
+			if (counter > 19){
+				clearInterval(caller);
+				caller = null;
+				expect(debounceCalls == 1).toBeTruthy();
+				return true;
+			}
+		}, 'some calls to happen', 1000);
+
+		waits(200);
+		waitsFor(function(){
+			if (!caller) startCaller();
+			if (counter > 40){
+				clearInterval(caller);
+				return true;
+			}
+		}, 'even more calls to happen', 1000);
+		waits(200);
+		runs(function(){
+			expect(debounceCalls == 2).toBeTruthy();
+		});
+	});
+
+	it('should debounce once early', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce({
+			when: 'early',
+			once: true,
+			delay: 150
+		});
+		waitsFor(function(){
+			if (counter > 19){
+				clearInterval(caller);
+				caller = null;
+				expect(debounceCalls == 1).toBeTruthy();
+				return true;
+			}
+		}, 'some calls to happen', 1000);
+
+		waits(200);
+		waitsFor(function(){
+			if (!caller) startCaller();
+			if (counter > 40){
+				clearInterval(caller);
+				return true;
+			}
+		}, 'even more calls to happen', 1000);
+		waits(200);
+		runs(function(){
+			expect(debounceCalls == 1).toBeTruthy();
+		});
+	});
+
+	it('should debounce late', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce(150);
+		waitsFor(function(){
+			if (counter > 19){
+				clearInterval(caller);
+				caller = null;
+				expect(debounceCalls == 0).toBeTruthy();
+				return true;
+			}
+		}, 'some calls to happen', 1000);
+
+		waits(200);
+		waitsFor(function(){
+			if (!caller){
+				expect(debounceCalls == 1).toBeTruthy();
+				startCaller();
+			}
+			if (counter > 40){
+				clearInterval(caller);
+				return true;
+			}
+		}, 'even more calls to happen', 1000);
+		waits(200);
+		runs(function(){
+			expect(debounceCalls == 2).toBeTruthy();
+		});
+	});
+
+	it('should debounce once late', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce({
+			when: 'late',
+			once: true
+		});
+		waitsFor(function(){
+			if (counter > 19){
+				clearInterval(caller);
+				caller = null;
+				expect(debounceCalls == 0).toBeTruthy();
+				return true;
+			}
+		}, 'some calls to happen', 1000);
+
+		waits(300);
+		waitsFor(function(){
+			if (!caller){
+				expect(debounceCalls == 1).toBeTruthy();
+				startCaller();
+			}
+			if (counter > 40){
+				clearInterval(caller);
+				return true;
+			}
+		}, 'even more calls to happen', 1000);
+		waits(300);
+		runs(function(){
+			expect(debounceCalls == 1).toBeTruthy();
+		});
+	});
+
+	it('should debounce both early and late', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce({
+			when: 'both',
+			delay: 150
+		});
+		waitsFor(function(){
+			if (counter > 19){
+				clearInterval(caller);
+				caller = null;
+				expect(debounceCalls == 1).toBeTruthy();
+				return true;
+			}
+		}, 'some calls to happen', 1000);
+
+		waits(200);
+		waitsFor(function(){
+			if (!caller){
+				expect(debounceCalls == 2).toBeTruthy();
+				startCaller();
+			}
+			if (counter > 40){
+				clearInterval(caller);
+				return true;
+			}
+		}, 'even more calls to happen', 1000);
+		waits(200);
+		runs(function(){
+			expect(debounceCalls == 4).toBeTruthy();
+		});
+	});
+
+	it('should debounce both early and late, once', function(){
+		expect(counter == debounceCalls && debounceCalls == 0).toBeTruthy(); // control spec
+		debounceFn = fn.debounce({
+			when: 'both',
+			once: true
+		});
+		waitsFor(function(){
+			if (counter > 19){
+				clearInterval(caller);
+				caller = null;
+				expect(debounceCalls == 1).toBeTruthy();
+				return true;
+			}
+		}, 'some calls to happen', 1000);
+
+		waits(300);
+		waitsFor(function(){
+			if (!caller){
+				expect(debounceCalls == 2).toBeTruthy();
+				startCaller();
+			}
+			if (counter > 40){
+				clearInterval(caller);
+				return true;
+			}
+		}, 'even more calls to happen', 1000);
+		waits(300);
+		runs(function(){
+			expect(debounceCalls == 2).toBeTruthy();
+		});
 	});
 
 });


### PR DESCRIPTION
New feature suggestion: Function.debounce. 
(related: https://github.com/mootools/mootools-core/issues/2694)

This method will return a new function that will be called only once per group of close calls. After a defined delay it will be abble to be called again.

#### Syntax:

	var debounceFn = myFn.debounce({delay: 100});

#### Arguments:

1. obj - (*mixed*) If this argument is a number it will use it as the *delay* timeout of the debounce. If this argument is a object it will allow more specific configuration. Leaving the argument empty will fall to default values.

#### Returns:

* (*function*) A debounce function that will be called only once per group of close function calls.

#### Options:

* *delay* - The delay after which the debounce function is called. Defaults to 250ms.
* *early* - If *true* will call the function in the beggining of each groups of calls. Defaults to *false*.
* *once* - If *true* will call the function only once per event handler. Defaults to *false*.


**Specs fiddle: http://jsfiddle.net/tcuzgeb1/**
**Simple demo: http://jsfiddle.net/m3v56e7u/**

Comments are welcome.
If you think this is not suitable for Core let me know too.