### PR TITLE
fix broken links in docs

### DIFF
--- a/Docs/Element/Element.md
+++ b/Docs/Element/Element.md
@@ -882,13 +882,13 @@ Clones the Element and returns the cloned one.
 
 ### Note:
 
-- The returned Element does not have attached events. To clone the events use [Element:cloneEvents](/Element/Element.Event#Element:cloneEvents).
+- The returned Element does not have attached events. To clone the events use [Element:cloneEvents](/core/Element/Element.Event#Element:cloneEvents).
 - Values stored in Element.Storage are not cloned.
 - The clone element and its children are stripped of ids, unless otherwise specified by the keepid parameter.
 
 ### See Also:
 
-- [Element:cloneEvents](/Element/Element.Event#Element:cloneEvents).
+- [Element:cloneEvents](/core/Element/Element.Event#Element:cloneEvents).
 
 
 

--- a/Docs/Request/Request.HTML.md
+++ b/Docs/Request/Request.HTML.md
@@ -175,7 +175,7 @@ The Request.HTML class will (by default) add a custom header that, if used for a
 
 ### See Also:
 
-- [$][], [Request](/Request/Request)
+- [$][], [Request](/core/Request/Request)
 
 [Request]: /core/Request/Request
 [$]: /core/Element/Element/#Window:dollar

--- a/Docs/Request/Request.JSON.md
+++ b/Docs/Request/Request.JSON.md
@@ -5,7 +5,7 @@ Wrapped Request with automated receiving of JavaScript Objects in JSON Format.
 
 ### Extends:
 
-[Request](/Request/Request)
+[Request](/core/Request/Request)
 
 ### Syntax:
 


### PR DESCRIPTION
This PR fixes some broken links refered in https://github.com/mootools/website/issues/206.
A fix in the `.md` parser will also be needed for the older docs versions that have this problem.
