### PR TITLE
Exports `Event` class

### DIFF
--- a/Source/Types/DOMEvent.js
+++ b/Source/Types/DOMEvent.js
@@ -123,7 +123,7 @@ DOMEvent.defineKeys({
 })();
 
 /*<1.3compat>*/
-var Event = DOMEvent;
+var Event = this.Event = DOMEvent;
 Event.Keys = {};
 /*</1.3compat>*/
 


### PR DESCRIPTION
If you require the `mootools-core-compat.js` using the CommonJS approach, the `Event` class is not exported. This PR fixes that.
