### PR TITLE
Types/Function: Remove unnecessary dependency on Types/Array in 1.2compat block.

### DIFF
--- a/Source/Types/Function.js
+++ b/Source/Types/Function.js
@@ -88,7 +88,7 @@ Function.implement({
 		return function(event){
 			var args = options.arguments;
 			args = (args != null) ? Array.from(args) : Array.slice(arguments, (options.event) ? 1 : 0);
-			if (options.event) args = [event || window.event].extend(args);
+			if (options.event) args.unshift(event || window.event);
 			var returns = function(){
 				return self.apply(options.bind || null, args);
 			};


### PR DESCRIPTION
The 1.2compat function `Function.create` uses another 1.2compat function `Array.extend`. Because of this, `Types/Function` depends on `Types/Array` (even though this isn't noted in the file header), while this is not really necessary.

Replaced the `[event].extend(args)` call with an `args.unshift(event)` call instead.