### PR TITLE
Class.Thenable

### DIFF
--- a/Docs/Class/Class.Extras.md
+++ b/Docs/Class/Class.Extras.md
@@ -74,6 +74,9 @@ Adds functions to the end of the call stack of the Chain instance.
 		function(){ this.start(0,1); }
 	); //Will fade the Element out and in twice.
 
+### Note:
+
+[Take care][resetThenable-note] when using Chain and [Class.Thenable][] together. When multiple "thenable" resolutions are chained, the registration of callbacks for later resolutions has to be chained as well.
 
 ### See Also:
 
@@ -442,6 +445,7 @@ If a Class has [Events][] as well as [Options][] implemented, every option begin
 
 [Class]: /core/Class/Class
 [Class:implement]: /core/Class/Class/#Class:implement
+[Class.Thenable]: /core/Class/Class/Class.Thenable
 [Fx]: /core/Fx/Fx
 [Fx.Tween]: /core/Fx/Fx.Tween
 [Request]: /core/Request/Request
@@ -451,3 +455,4 @@ If a Class has [Events][] as well as [Options][] implemented, every option begin
 [Options]: #Options
 [addEvent]: #Events:addEvent
 [addEvents]: #Events:addEvents
+[resetThenable-note]: /core/Class/Class.Thenable#Class.Thenable:resetThenable-note

--- a/Docs/Class/Class.Thenable.md
+++ b/Docs/Class/Class.Thenable.md
@@ -1,0 +1,227 @@
+Class: Class.Thenable {#Class.Thenable}
+=======================================
+
+A Utility Class. Its methods can be implemented with [Class:implement][] into any [Class][].
+It makes a Class "thenable" (see [Promises/A+][]), which means you can call its `then` method to integrate it in a [Promise][] style flow.
+
+### Syntax:
+
+#### For new classes:
+
+	var MyClass = new Class({ Implements: Class.Thenable });
+
+#### For existing classes:
+
+	MyClass.implement(Class.Thenable);
+
+### Implementing:
+
+- This class can be implemented into other classes to add its functionality to them.
+
+### Example:
+
+	var Promise = new Class({
+		Implements: Class.Thenable,
+		initialize: function(executor){
+			if (typeof executor !== 'function'){
+				throw new TypeError('Promise constructor takes a function argument.');
+			}
+
+			try {
+				executor(this.resolve.bind(this), this.reject.bind(this));
+			} catch (exception){
+				this.reject(exception);
+			}
+		},
+		resetThenable: function(){
+			throw new TypeError('A promise can only be resolved once.');
+		}
+	});
+
+	var myPromise = new Promise(function(resolve){
+		resolve('Hello promised world!');
+	});
+	myPromise.then(function(value){
+		console.log(value);
+	});
+
+### See Also:
+
+- [Class][]
+- [Promise][]
+
+
+Class.Thenable Method: then {#Class.Thenable:then}
+--------------------------------------------------
+
+Registers callbacks to receive the class's eventual value or the reason why it cannot be succesfully resolved.
+
+### Syntax:
+
+	myClass.then(onFulfilled, onRejected);
+
+### Arguments:
+
+1. onFulfilled - (*function*, optional) Function to execute when the value is succesfully resolved.
+2. onRejected  - (*function*, optional) Function to execute when the value cannot be succesfully resolved.
+
+### Returns:
+
+* (*object*) A new `Class.Thenable` instance that will have its value resolved based on the return values of the above mentioned arguments, compatible with [Promises/A+][].
+
+### Example:
+
+	var request = new Request();
+	request.send().then(function(response){ console.log(response); });
+
+
+Class.Thenable Method: catch {#Class.Thenable:catch}
+----------------------------------------------------
+
+Registers a callback to receive the reason why an eventual value cannot be succesfully resolved.
+
+### Syntax:
+
+	myClass.catch(onRejected);
+
+### Arguments:
+
+1. onRejected  - (*function*, optional) Function to execute when the value cannot be succesfully resolved.
+
+### Returns:
+
+* (*object*) A new `Class.Thenable` instance that will have its value resolved based on the return values of the above mentioned arguments, compatible with [Promises/A+][].
+
+### Example:
+
+	var request = new Request();
+	request.send().catch(function(reason){ console.log(reason); });
+
+
+Class.Thenable Method: resolve {#Class.Thenable:resolve}
+--------------------------------------------------------
+
+Function to resolve the eventual value of the `Thenable`.
+
+### Syntax:
+
+	myClass.resolve(value);
+
+### Arguments:
+
+1. value  - (*mixed*, optional) The value to resolve. If the value is "thenable" (like a [Promise][] or `Thenable`), it will be resolved with its eventual value (i.e. it will be resolved when the "thenable" is resolved).
+
+### Returns:
+
+* (*object*) This Class instance.
+
+### Example:
+
+	var MyClass = new Class({
+		Implements: Class.Thenable,
+		initialize: function(){
+			this.resolve('Hello world!');
+		}
+	});
+
+
+Class.Thenable Method: reject {#Class.Thenable:reject}
+------------------------------------------------------
+
+Function to make a `Thenable` rejected, that is to say it will not receive an eventual value.
+
+### Syntax:
+
+	myClass.reject(reason);
+
+### Arguments:
+
+1. reason  - (*mixed*, optional) The reason the `Thenable` will not be succesfully resolved, often an `Error` instance.
+
+### Returns:
+
+* (*object*) This Class instance.
+
+### Example:
+
+	var MyClass = new Class({
+		Implements: Class.Thenable,
+		initialize: function(){
+			this.reject(new Error('Cannot be succesfully resolved.'));
+		}
+	});
+
+
+Class.Thenable Method: getThenableState {#Class.Thenable:getThenableState}
+--------------------------------------------------------------------------
+
+Returns the state of the `Thenable` Class.
+
+### Syntax:
+
+	myClass.getThenableState();
+
+### Returns:
+
+* (*string*) The current state: "pending", "fulfilled" or "rejected".
+
+### Example:
+
+	var MyClass = new Class({
+		Implements: Class.Thenable,
+		initialize: function(){
+			console.log(this.getThenableState());
+		}
+	});
+
+
+Class.Thenable Method: resetThenable {#Class.Thenable:resetThenable}
+--------------------------------------------------------------------
+
+Resets the state of the `Thenable` Class, to make it usable multiple times. If the current `Thenable` state was not resolved yet, it will be rejected first and the `onRejected` handlers will be executed.
+
+Use with caution, this is not in line with [Promise][] behaviour: a once resolved `Thenable` can be resolved with a different value after it is reset. Useful in case a Class can intentionally receive resolved values multiple times, e.g. a `Request` instance that can be executed multiple times or an `Fx` instance that is used multiple times.
+
+### Syntax:
+
+	myClass.resetThenable(reason);
+
+### Arguments:
+
+1. reason  - (*mixed*, optional) The reason to pass when rejecting a currently unresolved state.
+
+### Returns:
+
+* (*object*) This Class instance.
+
+### Example:
+
+	var MyClass = new Class({
+		Implements: Class.Thenable,
+		initialize: function(){
+			var self = this;
+			this.addEvent('start', function(){
+				self.resetThenable();
+			});
+		}
+	});
+
+### Note: {#Class.Thenable:resetThenable-note}
+
+Take care when using [Chain][] and `Class.Thenable` together. When multiple resolutions are chained, the registration of callbacks for later resolutions has to be chained as well. Since `myClass.chain()` returns the class instance, `myClass.chain(fn).then(callback)` is equivalent to `myClass.chain(fn); myClass.then(callback)`, and so the callback is not chained to whatever `fn` does.
+
+To use `chain`, you can use one of the following patterns:
+
+	myClass.start().chain(function(){ this.start() }).chain(function(){ this.then(callback); });
+	myClass.start().chain(function(){ this.start().then(callback); });
+
+If your aim is to use a Promise style flow, you should probably not use `chain`, and just use `then` instead:
+
+	myClass.start().then(function(){ return myClass.start(); }).then(callback);
+
+
+[Chain]: /core/Class/Class.Extras#Chain
+[Class]: /core/Class/Class
+[Class:implement]: /core/Class/Class/#Class:implement
+[Promise]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Promise
+[Promises/A+]: https://promisesaplus.com/

--- a/Docs/Fx/Fx.md
+++ b/Docs/Fx/Fx.md
@@ -6,7 +6,7 @@ All of the other Fx Classes inherit from this one.
 
 ### Implements:
 
-- [Chain][], [Events][], [Options][]
+- [Chain][], [Class.Thenable][], [Events][], [Options][]
 
 
 
@@ -30,7 +30,7 @@ Fx Method: constructor {#Fx:constructor}
 * link       - (*string*: defaults to ignore) Can be 'ignore', 'cancel' and 'chain'.
 	* 'ignore' - Any calls made to start while the effect is running will be ignored. (Synonymous with 'wait': true from 1.x)
 	* 'cancel' - Any calls made to start while the effect is running will take precedence over the currently running transition. The new transition will start immediately, canceling the one that is currently running. (Synonymous with 'wait': false from 1.x)
-	* 'chain'  - Any calls made to start while the effect is running will be chained up, and will take place as soon as the current effect has finished, one after another.
+	* 'chain'  - Any calls made to start while the effect is running will be chained up, and will take place as soon as the current effect has finished, one after another. [Take care][resetThenable-note] when using "chain" in combination with Fx's thenable properties.
 * duration   - (*number*: defaults to 500) The duration of the effect in ms. Can also be one of:
 	* 'short'  - 250ms
 	* 'normal' - 500ms
@@ -38,6 +38,10 @@ Fx Method: constructor {#Fx:constructor}
 * transition - (*function*: defaults to ['sine:in:out'][Fx.Transitions:sine] The equation to use for the effect see [Fx.Transitions][]. Also accepts a string in the following form:
 
   transition\[:in\]\[:out\] - for example, 'linear', 'quad:in', 'back:in', 'bounce:out', 'elastic:out', 'sine:in:out'
+
+### Thenable:
+
+Fx implements `Class.Thenable` to make an Fx instance "thenable", i.e. `myFx.start().then(function(){ console.log('Done.'); });`. See [Class.Thenable][] for more information.
 
 ### Events:
 
@@ -202,7 +206,9 @@ Returns true if the animation is paused. You can use this to check if you need t
 [Fx.Transitions:sine]: /core/Fx/Fx.Transitions#Fx-Transitions:sine
 [Element:setStyle]: /core/Element/Element.Style#Element:setStyle
 [Chain]: /core/Class/Class.Extras#Chain
+[Class.Thenable]: /core/Class/Class.Thenable
 [Events]: /core/Class/Class.Extras#Events
 [Options]: /core/Class/Class.Extras#Options
 [Fx.Tween]: /core/Fx/Fx.Tween
 [Fx.Morph]: /core/Fx/Fx.Morph
+[resetThenable-note]: /core/Class/Class.Thenable#Class.Thenable:resetThenable-note

--- a/Docs/Request/Request.md
+++ b/Docs/Request/Request.md
@@ -5,7 +5,7 @@ An XMLHttpRequest Wrapper.
 
 ### Implements:
 
-[Chain][], [Events][], [Options][]
+[Chain][], [Class.Thenable][], [Events][], [Options][]
 
 ### Syntax:
 
@@ -23,7 +23,7 @@ An XMLHttpRequest Wrapper.
 * link       - (*string*: defaults to 'ignore') Can be 'ignore', 'cancel' and 'chain'.
 	* 'ignore' - Any calls made to start while the request is running will be ignored. (Synonymous with 'wait': true from 1.11)
 	* 'cancel' - Any calls made to start while the request is running will take precedence over the currently running request. The new request will start immediately, canceling the one that is currently running. (Synonymous with 'wait': false from 1.11)
-	* 'chain'  - Any calls made to start while the request is running will be chained up, and will take place as soon as the current request has finished, one after another.
+	* 'chain'  - Any calls made to start while the request is running will be chained up, and will take place as soon as the current request has finished, one after another. [Take care][resetThenable-note] when using "chain" in combination with Request's thenable properties.
 * method     - (*string*: defaults to 'post') The HTTP method for the request, can be either 'post' or 'get'.
 * emulation  - (*boolean*: defaults to *true*) If set to true, other methods than 'post' or 'get' are appended as post-data named '\_method' (as used in rails)
 * async      - (*boolean*: defaults to *true*) If set to false, the requests will be synchronous and freeze the browser during request.
@@ -38,6 +38,10 @@ An XMLHttpRequest Wrapper.
 * user       - (*string*: defaults to *null*) The username to use for http basic authentication.
 * password   - (*string*: defaults to *null*) You can use this option together with the `user` option to set authentication credentials when necessary. Note that the password will be passed as plain text and is therefore readable by anyone through the source code. It is therefore encouraged to use this option carefully
 * withCredentials   - (*boolean*: defaults to *false*) If set to true, xhr.withCredentials will be set to true allowing cookies/auth to be passed for cross origin requests
+
+### Thenable:
+
+Request implements `Class.Thenable` to make a Request instance "thenable", i.e. `myRequest.send().then(function(response){ console.log(response.text); });`. See [Class.Thenable][] for more information.
 
 ### Events:
 
@@ -468,7 +472,9 @@ Sends a form or a container of inputs with an HTML request.
 [Element.Properties]: /core/Element/Element/#Element-Properties
 [URI]: /more/Types/URI
 [Chain]: /core/Class/Class.Extras#Chain
+[Class.Thenable]: /core/Class/Class.Thenable
 [Events]: /core/Class/Class.Extras#Events
 [Options]: /core/Class/Class.Extras#Options
 [Object:toQueryString]: /core/Types/Object#Object:Object-toQueryString
 [Element:toQueryString]: /core/Element/Element#Element:toQueryString
+[resetThenable-note]: /core/Class/Class.Thenable#Class.Thenable:resetThenable-note

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,7 +26,7 @@ module.exports = function(grunt){
 				server: {
 					name: 'mootools-core-server',
 					sources: pkg.sources,
-					components: ['Core/Core', 'Core/Array', 'Core/String', 'Core/Number', 'Core/Function', 'Core/Object', 'Core/Class', 'Core/Class.Extras', 'Core/JSON'],
+					components: ['Core/Core', 'Core/Array', 'Core/String', 'Core/Number', 'Core/Function', 'Core/Object', 'Core/Class', 'Core/Class.Extras', 'Core/Class.Thenable', 'Core/JSON'],
 					strip: ['1.2compat', '1.3compat', '1.4compat', '*compat', 'IE', 'ltIE8', 'ltIE9', '!ES5', '!ES5-bind', 'webkit', 'ltFF4'],
 					specs: ['Specs/Core/*.js', 'Specs/Class/*.js', 'Specs/Types/*.js', 'Specs/Utilities/JSON.js'],
 					uglify: false

--- a/Source/Class/Class.Thenable.js
+++ b/Source/Class/Class.Thenable.js
@@ -1,0 +1,222 @@
+/*
+---
+
+name: Class.Thenable
+
+description: Contains a Utility Class that can be implemented into your own Classes to make them "thenable".
+
+license: MIT-style license.
+
+requires: Class
+
+provides: [Class.Thenable]
+
+...
+*/
+
+(function(){
+
+var STATE_PENDING = 0,
+	STATE_FULFILLED = 1,
+	STATE_REJECTED = 2;
+
+var Thenable = Class.Thenable = new Class({
+
+	$thenableState: STATE_PENDING,
+	$thenableResult: null,
+	$thenableReactions: [],
+
+	resolve: function(value){
+		resolve(this, value);
+		return this;
+	},
+
+	reject: function(reason){
+		reject(this, reason);
+		return this;
+	},
+
+	getThenableState: function(){
+		switch (this.$thenableState){
+			case STATE_PENDING:
+				return 'pending';
+
+			case STATE_FULFILLED:
+				return 'fulfilled';
+
+			case STATE_REJECTED:
+				return 'rejected';
+		}
+	},
+
+	resetThenable: function(reason){
+		reject(this, reason);
+		reset(this);
+		return this;
+	},
+
+	then: function(onFulfilled, onRejected){
+		if (typeof onFulfilled !== 'function') onFulfilled = 'Identity';
+		if (typeof onRejected !== 'function') onRejected = 'Thrower';
+
+		var thenable = new Thenable();
+
+		this.$thenableReactions.push({
+			thenable: thenable,
+			fulfillHandler: onFulfilled,
+			rejectHandler: onRejected
+		});
+
+		if (this.$thenableState !== STATE_PENDING){
+			react(this);
+		}
+
+		return thenable;
+	},
+
+	'catch': function(onRejected){
+		return this.then(null, onRejected);
+	}
+
+});
+
+Thenable.extend({
+	resolve: function(value){
+		var thenable;
+		if (value instanceof Thenable){
+			thenable = value;
+		} else {
+			thenable = new Thenable();
+			resolve(thenable, value);
+		}
+		return thenable;
+	},
+	reject: function(reason){
+		var thenable = new Thenable();
+		reject(thenable, reason);
+		return thenable;
+	}
+});
+
+// Private functions
+
+function resolve(thenable, value){
+	if (thenable.$thenableState === STATE_PENDING){
+		if (thenable === value){
+			reject(thenable, new TypeError('Tried to resolve a thenable with itself.'));
+		} else if (value && (typeof value === 'object' || typeof value === 'function')){
+			try {
+				var then = value.then;
+			} catch (exception){
+				reject(thenable, exception);
+			}
+			if (typeof then === 'function'){
+				var resolved = false;
+				defer(function(){
+					try {
+						then.call(
+							value,
+							function(nextValue){
+								if (!resolved){
+									resolved = true;
+									resolve(thenable, nextValue);
+								}
+							},
+							function(reason){
+								if (!resolved){
+									resolved = true;
+									reject(thenable, reason);
+								}
+							}
+						);
+					} catch (exception) {
+						if (!resolved){
+							resolved = true;
+							reject(thenable, exception);
+						}
+					}
+				});
+			} else {
+				fulfill(thenable, value);
+			}
+		} else {
+			fulfill(thenable, value);
+		}
+	}
+}
+
+function fulfill(thenable, value){
+	if (thenable.$thenableState === STATE_PENDING){
+		thenable.$thenableResult = value;
+		thenable.$thenableState = STATE_FULFILLED;
+
+		react(thenable);
+	}
+}
+
+function reject(thenable, reason){
+	if (thenable.$thenableState === STATE_PENDING){
+		thenable.$thenableResult = reason;
+		thenable.$thenableState = STATE_REJECTED;
+
+		react(thenable);
+	}
+}
+
+function reset(thenable){
+	if (thenable.$thenableState !== STATE_PENDING){
+		thenable.$thenableResult = null;
+		thenable.$thenableState = STATE_PENDING;
+	}
+}
+
+function react(thenable){
+	var state = thenable.$thenableState,
+		result = thenable.$thenableResult,
+		reactions = thenable.$thenableReactions,
+		type;
+
+	if (state === STATE_FULFILLED){
+		thenable.$thenableReactions = [];
+		type = 'fulfillHandler';
+	} else if (state == STATE_REJECTED){
+		thenable.$thenableReactions = [];
+		type = 'rejectHandler';
+	}
+
+	if (type){
+		defer(handle.pass([result, reactions, type]));
+	}
+}
+
+function handle(result, reactions, type){
+	for (var i = 0, l = reactions.length; i < l; ++i){
+		var reaction = reactions[i],
+			handler = reaction[type];
+
+		if (handler === 'Identity'){
+			resolve(reaction.thenable, result);
+		} else if (handler === 'Thrower'){
+			reject(reaction.thenable, result);
+		} else {
+			try {
+				resolve(reaction.thenable, handler(result));
+			} catch (exception) {
+				reject(reaction.thenable, exception);
+			}
+		}
+	}
+}
+
+var defer;
+if (typeof process !== 'undefined' && typeof process.nextTick === 'function'){
+	defer = process.nextTick;
+} else if (typeof setImmediate !== 'undefined'){
+	defer = setImmediate;
+} else {
+	defer = function(fn){
+		setTimeout(fn, 0);
+	};
+}
+
+})();

--- a/Source/Fx/Fx.js
+++ b/Source/Fx/Fx.js
@@ -7,7 +7,7 @@ description: Contains the basic animation logic to be extended by all other Fx C
 
 license: MIT-style license.
 
-requires: [Chain, Events, Options]
+requires: [Chain, Events, Options, Class.Thenable]
 
 provides: Fx
 
@@ -18,7 +18,7 @@ provides: Fx
 
 var Fx = this.Fx = new Class({
 
-	Implements: [Chain, Events, Options],
+	Implements: [Chain, Events, Options, Class.Thenable],
 
 	options: {
 		/*
@@ -92,6 +92,9 @@ var Fx = this.Fx = new Class({
 		this.duration = Fx.Durations[duration] || duration.toInt();
 		this.frameInterval = 1000 / fps;
 		this.frames = frames || Math.round(this.duration / this.frameInterval);
+		if (this.getThenableState() !== 'pending'){
+			this.resetThenable(this.subject);
+		}
 		this.fireEvent('start', this.subject);
 		pushInstance.call(this, fps);
 		return this;
@@ -107,6 +110,7 @@ var Fx = this.Fx = new Class({
 			} else {
 				this.fireEvent('stop', this.subject);
 			}
+			this.resolve(this.subject === this ? null : this.subject);
 		}
 		return this;
 	},
@@ -117,6 +121,7 @@ var Fx = this.Fx = new Class({
 			pullInstance.call(this, this.options.fps);
 			this.frame = this.frames;
 			this.fireEvent('cancel', this.subject).clearChain();
+			this.reject(this.subject);
 		}
 		return this;
 	},

--- a/Source/Request/Request.HTML.js
+++ b/Source/Request/Request.HTML.js
@@ -55,6 +55,7 @@ Request.HTML = new Class({
 		if (options.evalScripts) Browser.exec(response.javascript);
 
 		this.onSuccess(response.tree, response.elements, response.html, response.javascript);
+		this.resolve({tree: response.tree, elements: response.elements, html: response.html, javascript: response.javascript});
 	}
 
 });

--- a/Source/Request/Request.JSON.js
+++ b/Source/Request/Request.JSON.js
@@ -39,8 +39,12 @@ Request.JSON = new Class({
 			this.fireEvent('error', [text, error]);
 			return;
 		}
-		if (json == null) this.onFailure();
-		else this.onSuccess(json, text);
+		if (json == null){
+			this.failure();
+		} else {
+			this.onSuccess(json, text);
+			this.resolve({json: json, text: text});
+		}
 	}
 
 });

--- a/Specs/Class/Class.Thenable.js
+++ b/Specs/Class/Class.Thenable.js
@@ -16,24 +16,6 @@ describe('Class.Thenable', function(){
 
 	});
 
-	var aplusAdapter = {
-
-		resolved: Class.Thenable.resolve,
-
-		rejected: Class.Thenable.reject,
-
-		deferred: function(){
-			var thenable = new Class.Thenable();
-
-			return {
-				promise: thenable,
-				resolve: thenable.resolve.bind(thenable),
-				reject: thenable.reject.bind(thenable)
-			};
-		}
-
-	};
-
 	function asyncExpectations(done, fn){
 		var error,
 			finished = false;
@@ -52,6 +34,29 @@ describe('Class.Thenable', function(){
 			if (finished) return done(error);
 		}
 	}
+
+	describe('(Promises/A+)', function(){
+		var specs;
+		try {
+			specs = require('promises-aplus-tests');
+		} catch (error){
+			xspecify('specs cannot be run in this environment');
+		}
+		if (specs){
+			specs.mocha({
+				resolved: Thenable.resolve,
+				rejected: Thenable.reject,
+				deferred: function(){
+					var thenable = new Thenable();
+					return {
+						promise: thenable,
+						resolve: thenable.resolve.bind(thenable),
+						reject: thenable.reject.bind(thenable)
+					};
+				}
+			});
+		}
+	});
 
 	// Tests below are adapted versions of the tests in domenic/promises-unwrapping:
 	// https://github.com/domenic/promises-unwrapping/tree/master/reference-implementation/test

--- a/Specs/Class/Class.Thenable.js
+++ b/Specs/Class/Class.Thenable.js
@@ -8,6 +8,14 @@ provides: ~
 
 describe('Class.Thenable', function(){
 
+	var Thenable = Class.Thenable;
+
+	var Thing = new Class({
+
+		Implements: Thenable
+
+	});
+
 	var aplusAdapter = {
 
 		resolved: Class.Thenable.resolve,
@@ -26,8 +34,277 @@ describe('Class.Thenable', function(){
 
 	};
 
-	it('should have specs', function(){
-		throw new Error('No specs for Class.Thenable.');
+	function asyncExpectations(done, fn){
+		var error,
+			finished = false;
+
+		function notFinished(){
+			finished = false;
+		}
+
+		return function(){
+			finished = true;
+			try {
+				fn(notFinished);
+			} catch (thrown){
+				error = thrown;
+			}
+			if (finished) return done(error);
+		}
+	}
+
+	// Tests below are adapted versions of the tests in domenic/promises-unwrapping:
+	// https://github.com/domenic/promises-unwrapping/tree/master/reference-implementation/test
+	it('should call its fulfillment handler when fulfilled', function(done){
+		var expectations = asyncExpectations(done, function(){
+			expect(onFulfilled.called).to.equal(true);
+			expect(onRejected.called).to.equal(false);
+			expect(onFulfilled.args[0][0]).to.equal(5);
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+		var onRejected = sinon.spy(expectations);
+
+		Thenable.resolve(5).then(onFulfilled, onRejected);
+	});
+
+	it('should call its rejection handler when rejected', function(done){
+		var expectations = asyncExpectations(done, function(){
+			expect(onRejected.called).to.equal(true);
+			expect(onRejected.args[0][0]).to.equal(12);
+		});
+
+		var onRejected = sinon.spy(expectations);
+
+		Thenable.reject(12)['catch'](onRejected);
+	});
+
+	describe('implemented', function(){
+
+		it('should call its fulfillment handler when fulfilled', function(done){
+			var expectations = asyncExpectations(done, function(){
+				expect(onFulfilled.called).to.equal(true);
+				expect(onRejected.called).to.equal(false);
+				expect(onFulfilled.args[0][0]).to.equal(4);
+			});
+
+			var instance = new Thing();
+			var onFulfilled = sinon.spy(expectations);
+			var onRejected = sinon.spy(expectations);
+
+			instance.then(onFulfilled, onRejected);
+			instance.resolve(4);
+		});
+
+		it('should call its rejection handler when rejected', function(done){
+			var expectations = asyncExpectations(done, function(){
+				expect(onRejected.called).to.equal(true);
+				expect(onRejected.args[0][0]).to.equal(41);
+			});
+
+			var instance = new Thing();
+			var onRejected = sinon.spy(expectations);
+
+			instance.reject(41);
+			instance['catch'](onRejected);
+		});
+
+	});
+
+	it('should refuse to be resolved with itself', function(done){
+		var expectations = asyncExpectations(done, function(){
+			expect(onFulfilled.called).to.equal(false);
+			expect(onRejected.called).to.equal(true);
+			expect(onRejected.args[0][0] instanceof TypeError).to.equal(true);
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+		var onRejected = sinon.spy(expectations);
+
+		var thenable = new Thenable();
+		thenable.resolve(thenable).then(onFulfilled, onRejected);
+	});
+
+	it('should call handlers in the order they are queued, when added before resolution', function(done){
+		var expectations = asyncExpectations(done, function(notFinished){
+			if (onFulfilled.callCount == 2){
+				expect(calls[0]).to.equal(2);
+				expect(calls[1]).to.equal(1);
+			} else {
+				notFinished();
+			}
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+		var calls = [];
+
+		var t1 = new Thenable();
+		var t2 = new Thenable();
+
+		t1.then(function(){
+			calls.push(1);
+		}).then(onFulfilled);
+
+		t2['catch'](function(){
+			calls.push(2);
+		}).then(onFulfilled);
+
+		t2.reject();
+		t1.resolve();
+	});
+
+	it('should call handlers in the order they are queued, when added after resolution', function(done){
+		var expectations = asyncExpectations(done, function(notFinished){
+			if (onFulfilled.callCount == 2){
+				expect(calls[0]).to.equal(1);
+				expect(calls[1]).to.equal(2);
+			} else {
+				notFinished();
+			}
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+		var calls = [];
+
+		var t1 = new Thenable();
+		var t2 = new Thenable();
+
+		t2.reject();
+		t1.resolve();
+
+		t1.then(function(){
+			calls.push(1);
+		}).then(onFulfilled);
+
+		t2['catch'](function(){
+			calls.push(2);
+		}).then(onFulfilled);
+	});
+
+	it('should call handlers in the order they are queued, when added asynchronously after resolution', function(done){
+		var expectations = asyncExpectations(done, function(notFinished){
+			if (onFulfilled.callCount == 2){
+				expect(calls[0]).to.equal(1);
+				expect(calls[1]).to.equal(2);
+			} else {
+				notFinished();
+			}
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+		var calls = [];
+
+		var t1 = new Thenable();
+		var t2 = new Thenable();
+
+		t2.reject();
+		t1.resolve();
+
+		setTimeout(function(){
+			t1.then(function(){
+				calls.push(1);
+			}).then(onFulfilled);
+
+			t2['catch'](function(){
+				calls.push(2);
+			}).then(onFulfilled);
+		}, 0);
+	});
+
+	it('should resolve only once, even when resolved to a thenable that calls its handlers twice', function(done){
+		var expectations = asyncExpectations(done, function(){
+			expect(onFulfilled.callCount).to.equal(1);
+			expect(onFulfilled.args[0][0]).to.equal(1);
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+
+		var evilThenable = Thenable.resolve();
+		evilThenable.then = function(f){
+			f(1);
+			f(2);
+		};
+
+		var resolvedToEvil = new Thenable();
+		resolvedToEvil.resolve(evilThenable);
+		resolvedToEvil.then(onFulfilled);
+	});
+
+	it('should correctly store the first resolved value if resolved to a thenable which calls back with different values each time', function(done){
+		var expectations = asyncExpectations(done, function(){
+			expect(onFulfilled.called).to.equal(true);
+		});
+
+		var onFulfilled = sinon.spy(expectations);
+
+		var thenable = {
+			i: 0,
+			then: function(f){
+				f(this.i++);
+			}
+		};
+		var t = Thenable.resolve(thenable);
+
+		t.then(function(value){
+			expect(value).to.equal(0);
+
+			t.then(function(value){
+				expect(value).to.equal(0);
+
+				t.then(function(value){
+					expect(value).to.equal(0);
+				});
+			});
+		});
+
+		t.then(onFulfilled);
+	});
+
+	it('should call then methods with a clean stack when it resolves to a thenable', function(){
+		var then = sinon.spy();
+
+		var thenable = {
+			then: then
+		};
+
+		Thenable.resolve(thenable);
+
+		expect(then.called).to.equal(false);
+	});
+
+	it('should call then methods with a clean stack when it resolves to an (evil) Thenable', function(){
+		var then = sinon.spy();
+
+		var evilThenable = Thenable.resolve();
+		evilThenable.then = then;
+
+		Thenable.resolve(evilThenable);
+		expect(then.called).to.equal(false);
+	});
+
+	it('should reset correctly', function(){
+		var thenable = new Thenable.resolve(3)
+		expect(thenable.getThenableState()).to.equal('fulfilled');
+
+		thenable.resetThenable();
+		expect(thenable.getThenableState()).to.equal('pending');
+	});
+
+	it('should reject before resetting, if still pending', function(done){
+		var expectations = asyncExpectations(done, function(){
+			expect(onRejected.called).to.equal(true);
+			expect(onRejected.args[0][0]).to.equal(7);
+			expect(thenable.getThenableState()).to.equal('pending');
+		});
+
+		var onRejected = sinon.spy(expectations);
+
+		var thenable = new Thenable();
+		expect(thenable.getThenableState()).to.equal('pending');
+
+		thenable.then(null, onRejected);
+
+		thenable.resetThenable(7);
 	});
 
 });

--- a/Specs/Class/Class.Thenable.js
+++ b/Specs/Class/Class.Thenable.js
@@ -1,0 +1,33 @@
+/*
+---
+name: Class.Thenable
+requires: ~
+provides: ~
+...
+*/
+
+describe('Class.Thenable', function(){
+
+	var aplusAdapter = {
+
+		resolved: Class.Thenable.resolve,
+
+		rejected: Class.Thenable.reject,
+
+		deferred: function(){
+			var thenable = new Class.Thenable();
+
+			return {
+				promise: thenable,
+				resolve: thenable.resolve.bind(thenable),
+				reject: thenable.reject.bind(thenable)
+			};
+		}
+
+	};
+
+	it('should have specs', function(){
+		throw new Error('No specs for Class.Thenable.');
+	});
+
+});

--- a/Specs/Fx/Fx.js
+++ b/Specs/Fx/Fx.js
@@ -157,3 +157,60 @@ describe('Fx', function(){
 	});
 
 });
+
+describe('Fx (thenable)', function(){
+
+	beforeEach(function(){
+		this.fx = new Fx({
+			duration: 1,
+			transition: 'sine:in:out'
+		});
+
+		var self = this;
+		this.onFulfilled = sinon.spy(function(){ self.expectations.apply(self, arguments); });
+		this.onRejected = sinon.spy(function(){ self.expectations.apply(self, arguments); });
+
+		this.fx.then(this.onFulfilled, this.onRejected);
+	});
+
+	it('should fulfill when completed', function(done){
+		this.fx.start(10, 20);
+
+		expect(this.onRejected.called).to.equal(false);
+		expect(this.onFulfilled.called).to.equal(false);
+
+		this.expectations = function(){
+			var error;
+			try {
+				expect(this.onRejected.called).to.equal(false);
+				expect(this.onFulfilled.called).to.equal(true);
+				expect(this.onFulfilled.args[0][0]).to.equal(null);
+			} catch (thrown){
+				error = thrown;
+			}
+			done(error);
+		}
+	});
+
+	it('should reject when cancelled', function(done){
+		this.fx.start();
+
+		expect(this.onFulfilled.called).to.equal(false);
+		expect(this.onRejected.called).to.equal(false);
+
+		this.fx.cancel();
+
+		this.expectations = function(){
+			var error;
+			try {
+				expect(this.onFulfilled.called).to.equal(false);
+				expect(this.onRejected.called).to.equal(true);
+				expect(this.onRejected.args[0][0]).to.equal(this.fx);
+			} catch (thrown){
+				error = thrown;
+			}
+			done(error);
+		}
+	});
+
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "load-grunt-tasks": "^3.2",
     "mocha": "^2.3",
     "phantomjs": "^1.9",
+    "promises-aplus-tests": "^2.1",
     "sinon": "~1.14",
     "syn": "^0.1.2"
   }

--- a/package.yml
+++ b/package.yml
@@ -23,6 +23,7 @@ sources:
   - "Source/Browser/Browser.js"
   - "Source/Class/Class.js"
   - "Source/Class/Class.Extras.js"
+  - "Source/Class/Class.Thenable.js"
   - "Source/Slick/Slick.Parser.js"
   - "Source/Slick/Slick.Finder.js"
   - "Source/Element/Element.js"


### PR DESCRIPTION
This is code I made almost a year ago, I finished it (or actually mostly its specs) now we use Mocha, so I could integrate the [Promises/A+ tests][].

New Class mixin. When implemented in a Class, it makes the class "thenable" in the [Promises/A+][] sense of the word, meaning it can be used in Promise style flows by using its `then` method.

The implementation, however, is more than just a "then" method. Any instance of a Class implementing `Class.Thenable` is a `Promises/A+` compliant object (generally referred to as "a Promise") with only one exception: it is possible to reset the Class's value resolution state fully (rejecting pending reactions, and starting empty) to support a Class instance living for longer than just the lifetime of one value resolution.

Example using Request:

```javascript
var request = new Request();
request.send().then(function(response){ console.log(response.text); });
```

Example hooking into a native Promise:

```javascript
var request = new Request();
var promise = Promise.resolve(request);
request.send();
promise.then(function(response){ console.log(response.text); });
```

It's even quite easy to create an actual `Promise` Class if you want, but that seemed a bit redundant to include in MooTools Core. I used the actual way to do this as example in the Docs, though:

```javascript
var Promise = new Class({
    Implements: Class.Thenable,
    initialize: function(executor){
        if (typeof executor !== 'function'){
            throw new TypeError('Promise constructor takes a function argument.');
        }

        try {
            executor(this.resolve.bind(this), this.reject.bind(this));
        } catch (exception){
            this.reject(exception);
        }
    },
    resetThenable: function(){
        throw new TypeError('A promise can only be resolved once.');
    }
});
```

This also solves issue #2643.

Full Travis run:
- https://travis-ci.org/timwienk/mootools-core/builds/84324415

[Promises/A+ tests]: https://www.npmjs.com/package/promises-aplus-tests
[Promises/A+]: https://promisesaplus.com/