### PR TITLE
Workaround to "t" is not a valid email address warning

### DIFF
--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -649,9 +649,9 @@ var canChangeStyleHTML = (function(){
 var input = document.createElement('input'), volatileInputValue, html5InputSupport;
 
 // #2178
-input.value = 't';
+input.value = 'test@test.com';
 input.type = 'submit';
-volatileInputValue = input.value != 't';
+volatileInputValue = input.value != 'test@test.com';
 
 // #2443 - IE throws "Invalid Argument" when trying to use html5 input types
 try {


### PR DESCRIPTION
A simple workaround to the mighty annoying warning caused by `t` not being a valid email address.

<img width="455" alt="screen shot 2015-11-25 at 09 49 53" src="https://cloud.githubusercontent.com/assets/34213/11392420/e6c4fb5c-9359-11e5-88d2-0abead8fc9a5.png">
