### PR TITLE
Use Array.convert instead of Array.from, add compat layer for Array.from

### DIFF
--- a/Docs/Core/Core.md
+++ b/Docs/Core/Core.md
@@ -344,8 +344,8 @@ This method has been deprecated. Please use [Number.random](/core/Types/Number#N
 Function: $splat {#Deprecated-Functions:splat}
 -------------------------
 
-This method has been deprecated. Please use [Array.from](/core/Types/Array#Array:Array-from) instead.
-However `$splat` does *not* transform Array-like objects such as NodeList or FileList in arrays, `Array.from` does.
+This method has been deprecated. Please use [Array.convert](/core/Types/Array#Array:Array:convert) instead.
+However `$splat` does *not* transform Array-like objects such as NodeList or FileList in arrays, `Array.convert` does.
 
 
 Function: $time {#Deprecated-Functions:time}

--- a/Docs/Types/Array.md
+++ b/Docs/Types/Array.md
@@ -82,16 +82,14 @@ Returns a copy of the passed array.
 
 This is an array-specific equivalent of *$unlink* from MooTools 1.2.
 
-
-
-Function: Array.from {#Array:Array-from}
+Function: Array.convert {#Array:Array:convert}
 ----------------------------------
 
 Converts the argument passed in to an array if it is defined and not already an array.
 
 ### Syntax:
 
-	var splatted = Array.from(obj);
+	var splatted = Array.convert(obj);
 
 ### Arguments:
 
@@ -103,15 +101,13 @@ Converts the argument passed in to an array if it is defined and not already an 
 
 ### Example:
 
-	Array.from('hello'); // returns ['hello'].
-	Array.from(['a', 'b', 'c']); // returns ['a', 'b', 'c'].
+	Array.convert('hello'); // returns ['hello'].
+	Array.convert(['a', 'b', 'c']); // returns ['a', 'b', 'c'].
 
 ### Notes:
 
-This is equivalent to *$splat* from MooTools 1.2, with the exception of Array-like Objects such as NodeList or FileList which `Array.from` does transform in
+This is equivalent to *$splat* from MooTools 1.2, with the exception of Array-like Objects such as NodeList or FileList which `Array.convert` does transform in
 Arrays and `$splat` not.
-
-
 
 Array method: each {#Array:each}
 ---------------------------------
@@ -778,11 +774,28 @@ Converts an RGB color value to hexadecimal. Input array must be in one of the fo
 - [String:rgbToHex][]
 
 
+Deprecated Functions {#Deprecated-Functions}
+============================================
 
+Function: Array.from {#Deprecated-Functions:Array:Array:from}
+----------------------------------
+
+This method has been deprecated in MooTools 1.6, please use *[Array:convert][]* instead. 
+For backwards compatibility you can use the _compat layer_ that still uses the old implementation, overriding the Native ES6 implementation. 
+Please use instead _no compat_ version, unless you know why you have to use the _compat layer_.
+
+### See Also:
+
+ - [MDN Array:from][]
+
+
+
+[Array:convert]: /core/Types/Array/#Array:convert
 [Function:bind]: /core/Types/Function/#Function:bind
 [String:hexToRgb]: /core/Types/String/#String:hexToRgb
 [String:rgbToHex]: /core/Types/String/#String:rgbToHex
 [MDN Array]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array
+[MDN Array:from]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from
 [MDN Array:every]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/every
 [MDN Array:filter]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/filter
 [MDN Array:indexOf]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/indexOf

--- a/Docs/Types/Array.md
+++ b/Docs/Types/Array.md
@@ -782,7 +782,7 @@ Function: Array.from {#Deprecated-Functions:Array:Array:from}
 
 This method has been deprecated in MooTools 1.6, please use *[Array:convert][]* instead. 
 For backwards compatibility you can use the _compat layer_ that still uses the old implementation, overriding the Native ES6 implementation. 
-Please use instead _no compat_ version, unless you know why you have to use the _compat layer_.
+Please use the no compat version instead, unless you know why you have to use the _compat layer_.
 
 ### See Also:
 

--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -202,11 +202,11 @@ if (this.attachEvent && !this.addEventListener){
 }
 
 // IE fails on collections and <select>.options (refers to <select>)
-var arrayFrom = Array.from;
+var arrayFrom = Array.convert;
 try {
 	arrayFrom(document.html.childNodes);
 } catch (e){
-	Array.from = function(item){
+	Array.convert = function(item){
 		if (typeof item != 'string' && Type.isEnumerable(item) && typeOf(item) != 'array'){
 			var i = item.length, array = new Array(i);
 			while (i--) array[i] = item[i];
@@ -220,7 +220,7 @@ try {
 	['pop', 'push', 'reverse', 'shift', 'sort', 'splice', 'unshift', 'concat', 'join', 'slice'].each(function(name){
 		var method = prototype[name];
 		Array[name] = function(item){
-			return method.apply(Array.from(item), slice.call(arguments, 1));
+			return method.apply(Array.convert(item), slice.call(arguments, 1));
 		};
 	});
 }

--- a/Source/Class/Class.Extras.js
+++ b/Source/Class/Class.Extras.js
@@ -67,7 +67,7 @@ this.Events = new Class({
 		type = removeOn(type);
 		var events = this.$events[type];
 		if (!events) return this;
-		args = Array.from(args);
+		args = Array.convert(args);
 		events.each(function(fn){
 			if (delay) fn.delay(delay, this, args);
 			else fn.apply(this, args);

--- a/Source/Class/Class.js
+++ b/Source/Class/Class.js
@@ -106,7 +106,7 @@ Class.Mutators = {
 	},
 
 	Implements: function(items){
-		Array.from(items).each(function(item){
+		Array.convert(items).each(function(item){
 			var instance = new item;
 			for (var key in instance) implement.call(this, key, instance[key], true);
 		}, this);

--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -118,6 +118,11 @@ Function.prototype.implement = function(key, value){
 	this.prototype[key] = value;
 }.overloadSetter();
 
+Array.convert = function(item){
+	if (item == null) return [];
+	return (Type.isEnumerable(item) && typeof item != 'string') ? (typeOf(item) == 'array') ? item : slice.call(item) : [item];
+};
+
 // From
 
 var slice = Array.prototype.slice;
@@ -128,10 +133,9 @@ Function.from = function(item){
 	};
 };
 
-Array.from = function(item){
-	if (item == null) return [];
-	return (Type.isEnumerable(item) && typeof item != 'string') ? (typeOf(item) == 'array') ? item : slice.call(item) : [item];
-};
+/*<1.5compat>*/
+Array.from = Array.convert;
+/*</1.5compat>*/
 
 Number.from = function(item){
 	var number = parseFloat(item);
@@ -479,7 +483,7 @@ Array.type = function(item){
 };
 
 this.$A = function(item){
-	return Array.from(item).slice();
+	return Array.convert(item).slice();
 };
 
 this.$arguments = function(i){
@@ -526,7 +530,7 @@ this.$merge = function(){
 this.$lambda = Function.from;
 this.$mixin = Object.merge;
 this.$random = Number.random;
-this.$splat = Array.from;
+this.$splat = Array.convert;
 this.$time = Date.now;
 
 this.$type = function(object){

--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -118,14 +118,14 @@ Function.prototype.implement = function(key, value){
 	this.prototype[key] = value;
 }.overloadSetter();
 
+// From
+
+var slice = Array.prototype.slice;
+
 Array.convert = function(item){
 	if (item == null) return [];
 	return (Type.isEnumerable(item) && typeof item != 'string') ? (typeOf(item) == 'array') ? item : slice.call(item) : [item];
 };
-
-// From
-
-var slice = Array.prototype.slice;
 
 Function.from = function(item){
 	return (typeOf(item) == 'function') ? item : function(){

--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -103,7 +103,7 @@ Element.Properties.events = {set: function(events){
 	fireEvent: function(type, args, delay){
 		var events = this.retrieve('events');
 		if (!events || !events[type]) return this;
-		args = Array.from(args);
+		args = Array.convert(args);
 
 		events[type].keys.each(function(fn){
 			if (delay) fn.delay(delay, this, args);

--- a/Source/Element/Element.Style.js
+++ b/Source/Element/Element.Style.js
@@ -120,7 +120,7 @@ Element.implement({
 		property = camelCase(property == 'float' ? floatName : property);
 		if (typeOf(value) != 'string'){
 			var map = (Element.Styles[property] || '@').split(' ');
-			value = Array.from(value).map(function(val, i){
+			value = Array.convert(value).map(function(val, i){
 				if (!map[i]) return '';
 				return (typeOf(val) == 'number') ? map[i].replace('@', Math.round(val)) : val;
 			}).join(' ');

--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -754,7 +754,7 @@ Element.implement({
 	},
 
 	getProperties: function(){
-		var args = Array.from(arguments);
+		var args = Array.convert(arguments);
 		return args.map(this.getProperty, this).associate(args);
 	},
 
@@ -853,7 +853,7 @@ Element.implement({
 
 	getSelected: function(){
 		this.selectedIndex; // Safari 3.2.1
-		return new Elements(Array.from(this.options).filter(function(option){
+		return new Elements(Array.convert(this.options).filter(function(option){
 			return option.selected;
 		}));
 	},
@@ -869,7 +869,7 @@ Element.implement({
 				return document.id(opt).get('value');
 			}) : ((type == 'radio' || type == 'checkbox') && !el.checked) ? null : el.get('value');
 
-			Array.from(value).each(function(val){
+			Array.convert(value).each(function(val){
 				if (typeof val != 'undefined') queryString.push(encodeURIComponent(el.name) + '=' + encodeURIComponent(val));
 			});
 		});
@@ -938,7 +938,7 @@ Element.implement({
 	},
 
 	empty: function(){
-		Array.from(this.childNodes).each(Element.dispose);
+		Array.convert(this.childNodes).each(Element.dispose);
 		return this;
 	},
 
@@ -951,8 +951,8 @@ Element.implement({
 		var clone = this.cloneNode(contents), ce = [clone], te = [this], i;
 
 		if (contents){
-			ce.append(Array.from(clone.getElementsByTagName('*')));
-			te.append(Array.from(this.getElementsByTagName('*')));
+			ce.append(Array.convert(clone.getElementsByTagName('*')));
+			te.append(Array.convert(this.getElementsByTagName('*')));
 		}
 
 		for (i = ce.length; i--;){

--- a/Source/Fx/Fx.CSS.js
+++ b/Source/Fx/Fx.CSS.js
@@ -21,7 +21,7 @@ Fx.CSS = new Class({
 	//prepares the base from/to object
 
 	prepare: function(element, property, values){
-		values = Array.from(values);
+		values = Array.convert(values);
 		var from = values[0], to = values[1];
 		if (to == null){
 			to = from;
@@ -53,7 +53,7 @@ Fx.CSS = new Class({
 
 	parse: function(value){
 		value = Function.from(value)();
-		value = (typeof value == 'string') ? value.split(' ') : Array.from(value);
+		value = (typeof value == 'string') ? value.split(' ') : Array.convert(value);
 		return value.map(function(val){
 			val = String(val);
 			var found = false;

--- a/Source/Fx/Fx.Transitions.js
+++ b/Source/Fx/Fx.Transitions.js
@@ -33,7 +33,7 @@ Fx.implement({
 });
 
 Fx.Transition = function(transition, params){
-	params = Array.from(params);
+	params = Array.convert(params);
 	var easeIn = function(pos){
 		return transition(pos, params);
 	};

--- a/Source/Types/Array.js
+++ b/Source/Types/Array.js
@@ -173,7 +173,7 @@ Array.implement({
 Array.alias('extend', 'append');
 
 var $pick = this.$pick = function(){
-	return Array.from(arguments).pick();
+	return Array.convert(arguments).pick();
 };
 
 //</1.2compat>

--- a/Source/Types/Function.js
+++ b/Source/Types/Function.js
@@ -31,7 +31,7 @@ Function.implement({
 
 	attempt: function(args, bind){
 		try {
-			return this.apply(bind, Array.from(args));
+			return this.apply(bind, Array.convert(args));
 		} catch (e){}
 
 		return null;
@@ -60,7 +60,7 @@ Function.implement({
 
 	pass: function(args, bind){
 		var self = this;
-		if (args != null) args = Array.from(args);
+		if (args != null) args = Array.convert(args);
 		return function(){
 			return self.apply(bind, args || arguments);
 		};
@@ -87,7 +87,7 @@ Function.implement({
 		options = options || {};
 		return function(event){
 			var args = options.arguments;
-			args = (args != null) ? Array.from(args) : Array.slice(arguments, (options.event) ? 1 : 0);
+			args = (args != null) ? Array.convert(args) : Array.slice(arguments, (options.event) ? 1 : 0);
 			if (options.event) args.unshift(event || window.event);
 			var returns = function(){
 				return self.apply(options.bind || null, args);
@@ -101,7 +101,7 @@ Function.implement({
 
 	bind: function(bind, args){
 		var self = this;
-		if (args != null) args = Array.from(args);
+		if (args != null) args = Array.convert(args);
 		return function(){
 			return self.apply(bind, args || arguments);
 		};
@@ -109,14 +109,14 @@ Function.implement({
 
 	bindWithEvent: function(bind, args){
 		var self = this;
-		if (args != null) args = Array.from(args);
+		if (args != null) args = Array.convert(args);
 		return function(event){
 			return self.apply(bind, (args == null) ? arguments : [event].concat(args));
 		};
 	},
 
 	run: function(args, bind){
-		return this.apply(bind, Array.from(args));
+		return this.apply(bind, Array.convert(args));
 	}
 
 });

--- a/Source/Types/Number.js
+++ b/Source/Types/Number.js
@@ -47,7 +47,7 @@ var methods = {};
 
 math.each(function(name){
 	if (!Number[name]) methods[name] = function(){
-		return Math[name].apply(null, [this].concat(Array.from(arguments)));
+		return Math[name].apply(null, [this].concat(Array.convert(arguments)));
 	};
 });
 

--- a/Specs/Core/Core.js
+++ b/Specs/Core/Core.js
@@ -615,17 +615,17 @@ describe('instanceOf', function(){
 
 });
 
-describe('Array.from', function(){
+describe('Array.convert', function(){
 
 	it('should return the same array', function(){
 		var arr1 = [1, 2, 3];
-		var arr2 = Array.from(arr1);
+		var arr2 = Array.convert(arr1);
 		expect(arr1).to.equal(arr2);
 	});
 
 	it('should return an array for arguments', function(){
 		var fnTest = function(){
-			return Array.from(arguments);
+			return Array.convert(arguments);
 		};
 		var arr = fnTest(1, 2, 3);
 		expect(Type.isArray(arr)).to.equal(true);
@@ -633,21 +633,21 @@ describe('Array.from', function(){
 	});
 
 	it('should transform a non array into an array', function(){
-		expect(Array.from(1)).to.eql([1]);
+		expect(Array.convert(1)).to.eql([1]);
 	});
 
 	it('should transforum an undefined or null into an empty array', function(){
-		expect(Array.from(null)).to.eql([]);
-		expect(Array.from(undefined)).to.eql([]);
+		expect(Array.convert(null)).to.eql([]);
+		expect(Array.convert(undefined)).to.eql([]);
 	});
 
 	it('should ignore and return an array', function(){
-		expect(Array.from([1, 2, 3])).to.eql([1, 2, 3]);
+		expect(Array.convert([1, 2, 3])).to.eql([1, 2, 3]);
 	});
 
 	it('should return a copy of arguments or the arguments if it is of type array', function(){
 		// In Opera arguments is an array so it does not return a copy
-		// This is intended. Array.from is expected to return an Array from an array-like-object
+		// This is intended. Array.convert is expected to return an Array from an array-like-object
 		// It does not make a copy when the passed in value is an array already
 		var args,
 			type,
@@ -655,7 +655,7 @@ describe('Array.from', function(){
 				type = typeOf(arguments);
 				args = arguments;
 
-				return Array.from(arguments);
+				return Array.convert(arguments);
 			})(1, 2);
 
 		if (type === 'array'){
@@ -664,7 +664,6 @@ describe('Array.from', function(){
 			expect(copy).to.not.equal(args);
 		}
 	});
-
 });
 
 describe('String.from', function(){
@@ -844,7 +843,7 @@ describe('Array.each', function(){
 	it('should call the function for each item in Function arguments', function(){
 		var daysArr = [];
 		(function(){
-			Array.each(Array.from(arguments), function(value, key){
+			Array.each(Array.convert(arguments), function(value, key){
 				daysArr[key] = value;
 			});
 		})('Sun', 'Mon', 'Tue');
@@ -953,6 +952,7 @@ describe('Object.append', function(){
 
 });
 
+/*<!ES5>*/
 describe('Date.now', function(){
 
 	it('should return a timestamp', function(){
@@ -960,6 +960,7 @@ describe('Date.now', function(){
 	});
 
 });
+/*</!ES5>*/
 
 describe('String.uniqueID', function(){
 
@@ -1000,7 +1001,7 @@ describe('typeOf Client', function(){
 
 });
 
-describe('Array.from', function(){
+describe('Array.convert', function(){
 
 	var dit = typeof document == 'undefined' ? xit : it;
 	dit('should return an array for an Elements collection', function(){
@@ -1011,7 +1012,7 @@ describe('Array.from', function(){
 		div1.appendChild(div2);
 		div1.appendChild(div3);
 
-		var array = Array.from(div1.getElementsByTagName('*'));
+		var array = Array.convert(div1.getElementsByTagName('*'));
 		expect(Type.isArray(array)).to.equal(true);
 	});
 
@@ -1019,7 +1020,7 @@ describe('Array.from', function(){
 		var div = document.createElement('div');
 		div.innerHTML = '<select><option>a</option></select>';
 		var select = div.firstChild;
-		var array = Array.from(select.options);
+		var array = Array.convert(select.options);
 		expect(Type.isArray(array)).to.equal(true);
 	});
 

--- a/Specs/Element/Element.js
+++ b/Specs/Element/Element.js
@@ -354,7 +354,7 @@ describe('$$', function(){
 
 	it('should return all Elements of a specific tag', function(){
 		var divs1 = $$('div');
-		var divs2 = new Elements(Array.from(document.getElementsByTagName('div')));
+		var divs2 = new Elements(Array.convert(document.getElementsByTagName('div')));
 		expect(divs1).to.eql(divs2);
 	});
 

--- a/Specs/Types/Function.js
+++ b/Specs/Types/Function.js
@@ -13,7 +13,7 @@ var dit = /*<1.2compat>*/xit || /*</1.2compat>*/it; // Don't run unless no compa
 var MooTools = new String('MooTools');
 
 var fn = function(){
-	return Array.from(arguments).slice();
+	return Array.convert(arguments).slice();
 };
 
 var Rules = function(){


### PR DESCRIPTION
ES6 implemented `Array.from`, a method name that MooTools has since at least 2010. This pull request changes the MooTools implementation of `Array.from` to use the new native implementation. For older browsers that need a polyfill I added [MDN's polyfill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) to make it available to older browsers also.

For compatibility and consistency added `Array.convert` which is the old `Array.from` implementation, thus making it easier to update pre-change code.
The old `Array.from` implementation is not changed in the _compat layer_, still overriding the native implementation.

Since the old implementation was overwriting the native I think we don't need to change older versions.

Tested everything in Travis and got green.

Fixes #2757