### PR TITLE
Array.of, Object.values

### DIFF
--- a/Docs/Types/Array.md
+++ b/Docs/Types/Array.md
@@ -327,6 +327,34 @@ This method is provided only for browsers without native [Array:indexOf][] suppo
 - [MDN Array:indexOf][]
 
 
+Array method: of {#Array:of}
+--------------------------------
+
+Creates a new array from the arguments passed to the method. 
+This method is provided only for browsers without native [Array:of][] support.
+
+### Syntax:
+
+	var arr = Array.of(item0[, item1[, ...[, itemN]]]);
+
+### Returns:
+
+* (*array*) A array were the elements are the arguments passed to the method.
+
+### Arguments:
+
+1. item(s) - (*mixed*) Variable number of arguments.
+
+### Examples:
+
+	Array.of('apple', 'lemon', 'banana'); // returns ['apple', 'lemon', 'banana']
+	Array.of(19); // returns [19]
+
+### See Also:
+
+- [MDN Array:of][]
+
+
 
 Array method: map {#Array:map}
 ------------------------
@@ -792,5 +820,6 @@ Converts an RGB color value to hexadecimal. Input array must be in one of the fo
 [Array:every]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/every
 [Array:filter]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/filter
 [Array:indexOf]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/indexOf
+[Array:of]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of
 [Array:map]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/map
 [Array:some]: https://developer.mozilla.org/en/Core_JavaScript_1.5_Reference/Global_Objects/Array/some

--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -278,7 +278,7 @@ force('String', String, [
 	'charAt', 'charCodeAt', 'concat', 'contains', 'indexOf', 'lastIndexOf', 'match', 'quote', 'replace', 'search',
 	'slice', 'split', 'substr', 'substring', 'trim', 'toLowerCase', 'toUpperCase'
 ])('Array', Array, [
-	'pop', 'push', 'reverse', 'shift', 'sort', 'splice', 'unshift', 'concat', 'join', 'slice',
+	'pop', 'push', 'reverse', 'shift', 'sort', 'splice', 'unshift', 'concat', 'join', 'slice', 'of',
 	'indexOf', 'lastIndexOf', 'filter', 'forEach', 'every', 'map', 'some', 'reduce', 'reduceRight', 'contains'
 ])('Number', Number, [
 	'toExponential', 'toFixed', 'toLocaleString', 'toPrecision'
@@ -287,7 +287,7 @@ force('String', String, [
 ])('RegExp', RegExp, [
 	'exec', 'test'
 ])('Object', Object, [
-	'create', 'defineProperty', 'defineProperties', 'keys',
+	'create', 'defineProperty', 'defineProperties', 'keys', 'values',
 	'getPrototypeOf', 'getOwnPropertyDescriptor', 'getOwnPropertyNames',
 	'preventExtensions', 'isExtensible', 'seal', 'isSealed', 'freeze', 'isFrozen'
 ])('Date', Date, ['now']);

--- a/Source/Types/Array.js
+++ b/Source/Types/Array.js
@@ -168,6 +168,12 @@ Array.implement({
 
 });
 
+/*<!ES6>*/
+Array.extend('of', function(){
+	return Array.from(arguments);
+});
+/*</!ES6>*/
+
 //<1.2compat>
 
 Array.alias('extend', 'append');

--- a/Specs/Types/Array.js
+++ b/Specs/Types/Array.js
@@ -86,6 +86,15 @@ describe('Array', function(){
 
 	});
 
+	describe('Array.of', function(){
+
+		it('should create a array from the arguments received', function(){
+			var arr = Array.of(1, 2, 3, 0, 0, 0);
+			expect(arr).to.eql([1, 2, 3, 0, 0, 0]);
+		});
+
+	});
+
 	describe('Array.every', function(){
 
 		it('should return true if every item matches the comparator, otherwise false', function(){


### PR DESCRIPTION
 - Add polyfill to ES6’s Array.of and pre-check so we don't overwrite it.
 - Add pre-check for ES7’s Object.values so we don't overwrite it. Our `Object.values()` is [alike ES7's](https://github.com/tc39/proposal-object-values-entries/blob/master/spec.md).  