### PR TITLE
Rename <Type>.from to <Type>.convert

### DIFF
--- a/Docs/Core/Core.md
+++ b/Docs/Core/Core.md
@@ -285,11 +285,11 @@ If you really need this function you can implement it like so:
 Function: $empty {#Deprecated-Functions:empty}
 -------------------------
 
-This method has been deprecated. Use [Function.from](/core/Types/Function#Function:Function-from) instead.
+This method has been deprecated. Use [Function.convert](/core/Types/Function#Function:Function:convert) instead.
 
 ### Example:
 
-	var myFunc = Function.from();
+	var myFunc = Function.convert();
 	// or better:
 	var myFunc = function(){};
 
@@ -298,11 +298,11 @@ This method has been deprecated. Use [Function.from](/core/Types/Function#Functi
 Function: $lambda {#Deprecated-Functions:lambda}
 ---------------------------
 
-This method has been deprecated. Use [Function.from](/core/Types/Function#Function:Function-from) instead.
+This method has been deprecated. Use [Function.convert](/core/Types/Function#Function:Function:convert) instead.
 
 ### Example:
 
-	myLink.addEvent('click', Function.from(false)); // prevents a link Element from being clickable
+	myLink.addEvent('click', Function.convert(false)); // prevents a link Element from being clickable
 
 
 

--- a/Docs/Types/Function.md
+++ b/Docs/Types/Function.md
@@ -9,14 +9,14 @@ Function Methods.
 
 
 
-Function: Function.from {#Function:Function-from}
+Function: Function.convert {#Function:Function:convert}
 -------------------------------------------------
 
 If the passed argument is a function, it will return itself. Otherwise, it will return a function that returns the passed argument.
 
 ### Syntax:
 
-	var foo = Function.from(obj);
+	var foo = Function.convert(obj);
 
 ### Arguments:
 
@@ -28,18 +28,18 @@ If the passed argument is a function, it will return itself. Otherwise, it will 
 
 ### Examples:
 
-	var fn = Function.from(42);
+	var fn = Function.convert(42);
 	alert(fn());	// alerts '42'
 
-	var fn2 = Function.from(fn);
+	var fn2 = Function.convert(fn);
 	alert(fn2());	// alerts '42'
 
 ### Notes:
 
 This function is equivalent to the following deprecated MooTools 1.2 methods:
 
-	var fn1 = Function.from();		// equivalent to var fn1 = function(){};
-	var fn2 = Function.from(foo);	// equivalent to var fn2 = function(){ return foo; };
+	var fn1 = Function.convert();		// equivalent to var fn1 = function(){};
+	var fn2 = Function.convert(foo);	// equivalent to var fn2 = function(){ return foo; };
 
 
 Function: Function.attempt {#Function:Function-attempt}

--- a/Docs/Types/Number.md
+++ b/Docs/Types/Number.md
@@ -13,14 +13,14 @@ Every Math method is mirrored in the Number object, both as prototype and generi
 
 
 
-Function: Number.from {#Number:Number-from}
+Function: Number.convert {#Number:Number:convert}
 ------------------------------------
 
 Returns the passed parameter as a Number, or null if not a number.
 
 ### Syntax:
 
-	Number.from(arg);
+	Number.convert(arg);
 
 ### Arguments:
 
@@ -33,8 +33,8 @@ Returns the passed parameter as a Number, or null if not a number.
 
 ### Example:
 
-	Number.from('12')		// returns 12
-	Number.from('hello')	// returns null
+	Number.convert('12')		// returns 12
+	Number.convert('hello')	// returns null
 
 
 

--- a/Docs/Types/String.md
+++ b/Docs/Types/String.md
@@ -9,14 +9,14 @@ A collection of the String Object methods and functions.
 
 
 
-Function: String.from {#String:String-from}
+Function: String.convert {#String:String:convert}
 ------------------------------------
 
 Returns the passed parameter as a String.
 
 ### Syntax:
 
-	String.from(arg);
+	String.convert(arg);
 
 ### Arguments:
 
@@ -28,8 +28,8 @@ Returns the passed parameter as a String.
 
 ### Example:
 
-	String.from(2); // returns '2'
-	String.from(true); // returns 'true'
+	String.convert(2); // returns '2'
+	String.convert(true); // returns 'true'
 
 
 

--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -170,7 +170,7 @@ Browser.extend({
 
 this.Window = this.$constructor = new Type('Window', function(){});
 
-this.$family = Function.from('window').hide();
+this.$family = Function.convert('window').hide();
 
 Window.mirror(function(name, method){
 	window[name] = method;
@@ -178,7 +178,7 @@ Window.mirror(function(name, method){
 
 this.Document = document.$constructor = new Type('Document', function(){});
 
-document.$family = Function.from('document').hide();
+document.$family = Function.convert('document').hide();
 
 Document.mirror(function(name, method){
 	document[name] = method;

--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -127,24 +127,29 @@ Array.convert = function(item){
 	return (Type.isEnumerable(item) && typeof item != 'string') ? (typeOf(item) == 'array') ? item : slice.call(item) : [item];
 };
 
-Function.from = function(item){
+Function.convert = function(item){
 	return (typeOf(item) == 'function') ? item : function(){
 		return item;
 	};
+};
+
+
+Number.convert = function(item){
+	var number = parseFloat(item);
+	return isFinite(number) ? number : null;
+};
+
+String.convert = function(item){
+	return item + '';
 };
 
 /*<1.5compat>*/
 Array.from = Array.convert;
 /*</1.5compat>*/
 
-Number.from = function(item){
-	var number = parseFloat(item);
-	return isFinite(number) ? number : null;
-};
-
-String.from = function(item){
-	return item + '';
-};
+Function.from = Function.convert;
+Number.from = Number.convert;
+String.from = String.convert;
 
 // hide, protect
 
@@ -527,7 +532,7 @@ this.$merge = function(){
 	return Object.merge.apply(null, args);
 };
 
-this.$lambda = Function.from;
+this.$lambda = Function.convert;
 this.$mixin = Object.merge;
 this.$random = Number.random;
 this.$splat = Array.convert;

--- a/Source/Element/Element.Event.js
+++ b/Source/Element/Element.Event.js
@@ -39,7 +39,7 @@ Element.Properties.events = {set: function(events){
 					return true;
 				};
 			}
-			if (custom.base) realType = Function.from(custom.base).call(this, type);
+			if (custom.base) realType = Function.convert(custom.base).call(this, type);
 		}
 		var defn = function(){
 			return fn.call(self);
@@ -70,7 +70,7 @@ Element.Properties.events = {set: function(events){
 		var custom = Element.Events[type];
 		if (custom){
 			if (custom.onRemove) custom.onRemove.call(this, fn, type);
-			if (custom.base) type = Function.from(custom.base).call(this, type);
+			if (custom.base) type = Function.convert(custom.base).call(this, type);
 		}
 		return (Element.NativeEvents[type]) ? this.removeListener(type, value, arguments[2]) : this;
 	},

--- a/Source/Element/Element.js
+++ b/Source/Element/Element.js
@@ -73,7 +73,7 @@ if (!Browser.Element){
 
 	Element.Prototype = {
 		'$constructor': Element,
-		'$family': Function.from('element').hide()
+		'$family': Function.convert('element').hide()
 	};
 
 	Element.mirror(function(name, method){

--- a/Source/Fx/Fx.CSS.js
+++ b/Source/Fx/Fx.CSS.js
@@ -52,7 +52,7 @@ Fx.CSS = new Class({
 	//parses a value into an array
 
 	parse: function(value){
-		value = Function.from(value)();
+		value = Function.convert(value)();
 		value = (typeof value == 'string') ? value.split(' ') : Array.convert(value);
 		return value.map(function(val){
 			val = String(val);
@@ -74,7 +74,7 @@ Fx.CSS = new Class({
 		(Math.min(from.length, to.length)).times(function(i){
 			computed.push({value: from[i].parser.compute(from[i].value, to[i].value, delta), parser: from[i].parser});
 		});
-		computed.$family = Function.from('fx:css:value');
+		computed.$family = Function.convert('fx:css:value');
 		return computed;
 	},
 
@@ -159,7 +159,7 @@ Fx.CSS.Parsers = {
 	},
 
 	String: {
-		parse: Function.from(false),
+		parse: Function.convert(false),
 		compute: function(zero, one){
 			return one;
 		},

--- a/Specs/Core/Core.js
+++ b/Specs/Core/Core.js
@@ -666,39 +666,39 @@ describe('Array.convert', function(){
 	});
 });
 
-describe('String.from', function(){
+describe('String.convert', function(){
 
 	it('should convert to type string', function(){
-		expect(typeOf(String.from('string'))).to.equal('string');
-		expect(typeOf(String.from(1))).to.equal('string');
-		expect(typeOf(String.from(new Date))).to.equal('string');
-		expect(typeOf(String.from(function(){}))).to.equal('string');
+		expect(typeOf(String.convert('string'))).to.equal('string');
+		expect(typeOf(String.convert(1))).to.equal('string');
+		expect(typeOf(String.convert(new Date))).to.equal('string');
+		expect(typeOf(String.convert(function(){}))).to.equal('string');
 	});
 
 });
 
-describe('Function.from', function(){
+describe('Function.convert', function(){
 
 	it('if a function is passed in that function should be returned', function(){
 		var fn = function(a){ return a; };
-		expect(Function.from(fn)).to.equal(fn);
+		expect(Function.convert(fn)).to.equal(fn);
 	});
 
 	it('should return a function that returns the value passed when called', function(){
-		expect(Function.from('hello world!')()).to.equal('hello world!');
+		expect(Function.convert('hello world!')()).to.equal('hello world!');
 	});
 
 });
 
-describe('Number.from', function(){
+describe('Number.convert', function(){
 
 	it('should return the number representation of a string', function(){
-		expect(Number.from('10')).to.equal(10);
-		expect(Number.from('10px')).to.equal(10);
+		expect(Number.convert('10')).to.equal(10);
+		expect(Number.convert('10px')).to.equal(10);
 	});
 
 	it('should return null when it fails to return a number type', function(){
-		expect(Number.from('ciao')).to.equal(null);
+		expect(Number.convert('ciao')).to.equal(null);
 	});
 
 });

--- a/Specs/Types/Function.js
+++ b/Specs/Types/Function.js
@@ -165,7 +165,7 @@ describe('Function Method', function(){
 		});
 
 		it('should return the return value of a function', function(){
-			var fnc = Function.from('hello world!');
+			var fnc = Function.convert('hello world!');
 			expect(fnc.attempt()).to.equal('hello world!');
 		});
 


### PR DESCRIPTION
Rename other Types to follow same logic as Array.from -> Array.convert

Added no compat layer tags, and no other notice in docs. 
I supose the blog post of the next version should reflect this change alone.