### PR TITLE
Fix typos in comments and strings

### DIFF
--- a/Docs/Class/Class.Thenable.md
+++ b/Docs/Class/Class.Thenable.md
@@ -54,7 +54,7 @@ It makes a Class "thenable" (see [Promises/A+][]), which means you can call its 
 Class.Thenable Method: then {#Class.Thenable:then}
 --------------------------------------------------
 
-Registers callbacks to receive the class's eventual value or the reason why it cannot be succesfully resolved.
+Registers callbacks to receive the class's eventual value or the reason why it cannot be successfully resolved.
 
 ### Syntax:
 
@@ -62,8 +62,8 @@ Registers callbacks to receive the class's eventual value or the reason why it c
 
 ### Arguments:
 
-1. onFulfilled - (*function*, optional) Function to execute when the value is succesfully resolved.
-2. onRejected  - (*function*, optional) Function to execute when the value cannot be succesfully resolved.
+1. onFulfilled - (*function*, optional) Function to execute when the value is successfully resolved.
+2. onRejected  - (*function*, optional) Function to execute when the value cannot be successfully resolved.
 
 ### Returns:
 
@@ -78,7 +78,7 @@ Registers callbacks to receive the class's eventual value or the reason why it c
 Class.Thenable Method: catch {#Class.Thenable:catch}
 ----------------------------------------------------
 
-Registers a callback to receive the reason why an eventual value cannot be succesfully resolved.
+Registers a callback to receive the reason why an eventual value cannot be successfully resolved.
 
 ### Syntax:
 
@@ -86,7 +86,7 @@ Registers a callback to receive the reason why an eventual value cannot be succe
 
 ### Arguments:
 
-1. onRejected  - (*function*, optional) Function to execute when the value cannot be succesfully resolved.
+1. onRejected  - (*function*, optional) Function to execute when the value cannot be successfully resolved.
 
 ### Returns:
 
@@ -136,7 +136,7 @@ Function to make a `Thenable` rejected, that is to say it will not receive an ev
 
 ### Arguments:
 
-1. reason  - (*mixed*, optional) The reason the `Thenable` will not be succesfully resolved, often an `Error` instance.
+1. reason  - (*mixed*, optional) The reason the `Thenable` will not be successfully resolved, often an `Error` instance.
 
 ### Returns:
 
@@ -147,7 +147,7 @@ Function to make a `Thenable` rejected, that is to say it will not receive an ev
 	var MyClass = new Class({
 		Implements: Class.Thenable,
 		initialize: function(){
-			this.reject(new Error('Cannot be succesfully resolved.'));
+			this.reject(new Error('Cannot be successfully resolved.'));
 		}
 	});
 

--- a/Docs/Class/Class.md
+++ b/Docs/Class/Class.md
@@ -72,7 +72,7 @@ Useful when implementing a default set of properties in multiple Classes. The Im
 	var Cat = new Class({
 		Extends: Animal,
 		initialize: function(name, age){
-			this.parent(age); // calls initalize method of Animal class
+			this.parent(age); // calls initialize method of Animal class
 			this.name = name;
 		}
 	});

--- a/Docs/Element/Element.md
+++ b/Docs/Element/Element.md
@@ -952,7 +952,7 @@ Tests the Element to see if it has the passed in className.
 Element Method: addClass {#Element:addClass}
 --------------------------------------------
 
-Adds the passed in class to the Element, if the Element doesnt already have it.
+Adds the passed in class to the Element, if the Element doesn't already have it.
 
 ### Syntax:
 
@@ -1096,7 +1096,7 @@ As [Element:getPrevious][], but tries to find the nextSibling (excluding text no
 
 ### Arguments:
 
-1. match - (*string*, optional): A comma seperated list of tag names to match the found element(s) with. A full CSS selector can be passed.
+1. match - (*string*, optional): A comma separated list of tag names to match the found element(s) with. A full CSS selector can be passed.
 
 ### Returns:
 

--- a/Docs/Types/Function.md
+++ b/Docs/Types/Function.md
@@ -65,7 +65,7 @@ Tries to execute a number of functions. Returns immediately the return value of 
 	var result = Function.attempt(function(){
 		return some.made.up.object;
 	}, function(){
-		return jibberish.that.doesnt.exists;
+		return jibberish.that.does.not.exist;
 	}, function(){
 		return false;
 	});

--- a/Grunt/plugins/karma/syn/lib/syn.js
+++ b/Grunt/plugins/karma/syn/lib/syn.js
@@ -2558,7 +2558,7 @@ extend(syn, {
 				prevents = autoPrevent ? -1 : 0;
 
 			//automatically prevents the default behavior for this event
-			//this is to protect agianst nasty browser freezing bug in safari
+			//this is to protect against nasty browser freezing bug in safari
 			if (autoPrevent) {
 				bind(element, type, function ontype(ev) {
 					ev.preventDefault();

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ b. __To fix a bug:__
    6. Create Pull Request, and send Pull Request.
 
 
-__Do try to contibute!__ This is a community project.
+__Do try to contribute!__ This is a community project.
 
 
 ## Building & Testing

--- a/Source/Element/Element.Dimensions.js
+++ b/Source/Element/Element.Dimensions.js
@@ -283,7 +283,7 @@ function getCompatElement(element){
 })();
 
 //aliases
-Element.alias({position: 'setPosition'}); //compatability
+Element.alias({position: 'setPosition'}); //compatibility
 
 [Window, Document, Element].invoke('implement', {
 

--- a/Source/Slick/Slick.Finder.js
+++ b/Source/Slick/Slick.Finder.js
@@ -78,7 +78,7 @@ local.setDocument = function(document){
 	var testRoot = document.body || document.getElementsByTagName('body')[0] || root;
 	testRoot.appendChild(testNode);
 
-	// on non-HTML documents innerHTML and getElementsById doesnt work properly
+	// on non-HTML documents innerHTML and getElementsById don't work properly
 	try {
 		testNode.innerHTML = '<a id="'+id+'"></a>';
 		features.isHTMLDocument = !!document.getElementById(id);
@@ -117,7 +117,7 @@ local.setDocument = function(document){
 				cachedGetElementsByClassName = (testNode.getElementsByClassName('b').length != 2);
 			} catch (e){};
 
-			// Opera 9.6 getElementsByClassName doesnt detects the class if its not the first one
+			// Opera 9.6 getElementsByClassName doesn't detects the class if its not the first one
 			try {
 				testNode.innerHTML = '<a class="a"></a><a class="f b a"></a>';
 				brokenSecondClassNameGEBCN = (testNode.getElementsByClassName('a').length != 2);
@@ -134,13 +134,13 @@ local.setDocument = function(document){
 				features.starSelectsClosedQSA = (selected && !!selected.length && selected[0].nodeName.charAt(0) == '/');
 			} catch (e){}
 
-			// Safari 3.2 querySelectorAll doesnt work with mixedcase on quirksmode
+			// Safari 3.2 querySelectorAll doesn't work with mixedcase on quirksmode
 			try {
 				testNode.innerHTML = '<a class="MiX"></a>';
 				features.brokenMixedCaseQSA = !testNode.querySelectorAll('.MiX').length;
 			} catch (e){}
 
-			// Webkit and Opera dont return selected options on querySelectorAll
+			// Webkit and Opera don't return selected options on querySelectorAll
 			try {
 				testNode.innerHTML = '<select><option selected="selected">a</option></select>';
 				features.brokenCheckedQSA = (testNode.querySelectorAll(':checked').length == 0);

--- a/Specs/Types/String.js
+++ b/Specs/Types/String.js
@@ -76,7 +76,7 @@ describe('String Method', function(){
 	describe('String.test', function(){
 
 		it('should return true if the test matches the string otherwise false', function(){
-			expect('i like teh cookies'.test('cookies')).to.equal(true);
+			expect('i like the cookies'.test('cookies')).to.equal(true);
 			expect('i like cookies'.test('ke coo')).to.equal(true);
 			expect('I LIKE COOKIES'.test('cookie', 'i')).to.equal(true);
 			expect('i like cookies'.test('cookiez')).to.equal(false);

--- a/prepare-release
+++ b/prepare-release
@@ -87,7 +87,7 @@ if [ -n "$DIST" ]; then
 	echo "Building '$DIST_DIR' files." >&2
 	sh -c "cd '$DIR' && $DIST $DIST_ARGS" || moo "Error building '$DIST_DIR' files."
 	sh -c "cd '$DIR' && git add -f '$DIR/$DIST_DIR'" || moo "Error adding '$DIST_DIR' files to repository."
-	echo "Succesfully built '$DIST_DIR' files." >&2
+	echo "Successfully built '$DIST_DIR' files." >&2
 fi
 
 # Make the new release final.


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>