### PR TITLE
removing linebreak rule from ESLint for OS compatibility

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,6 @@ rules:
   no-octal: 0
   no-undef: 0
   no-unused-vars: 0
-  linebreak-style: [2, unix]
   no-trailing-spaces: 2
   no-unneeded-ternary: 2
   quotes: [2, single, avoid-escape]


### PR DESCRIPTION
Solves the following issue: https://github.com/mootools/mootools-core/issues/2769