### PR TITLE
remove ie8 and ie7 from Travis/Sauce Labs setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ env:
     - BUILD='compat'     BROWSER='ie11'
     - BUILD='compat'     BROWSER='ie10'
     - BUILD='compat'     BROWSER='ie9'
-    - BUILD='compat'     BROWSER='ie8'
-    - BUILD='compat'     BROWSER='ie7'
 
     - BUILD='nocompat'   BROWSER='phantomjs'
     - BUILD='nocompat'   BROWSER='chrome'
@@ -32,8 +30,6 @@ env:
     - BUILD='nocompat'   BROWSER='ie11'
     - BUILD='nocompat'   BROWSER='ie10'
     - BUILD='nocompat'   BROWSER='ie9'
-    - BUILD='nocompat'   BROWSER='ie8'
-    - BUILD='nocompat'   BROWSER='ie7'
 
     - BUILD='server'
 

--- a/Grunt/options/browsers.json
+++ b/Grunt/options/browsers.json
@@ -77,24 +77,6 @@
 		"browserName": "internet explorer",
 		"version": "9"
 	},
-	"ie8": {
-		"base": "SauceLabs",
-		"platform": "Windows 7",
-		"browserName": "internet explorer",
-		"version": "8"
-	},
-	"ie7": {
-		"base": "SauceLabs",
-		"platform": "Windows XP",
-		"browserName": "internet explorer",
-		"version": "7"
-	},
-	"ie6": {
-		"base": "SauceLabs",
-		"platform": "Windows XP",
-		"browserName": "internet explorer",
-		"version": "6"
-	},
 	"android": {
 		"base": "SauceLabs",
 		"platform": "Linux",


### PR DESCRIPTION
Remove ie8 and ie7 from Travis/Sauce Labs setup due to [ended support for IE7](https://wiki.saucelabs.com/pages/viewpage.action?pageId=70068108) and problems connecting Travis and SauceLabs on IE8