### PR TITLE
Extract only javascript scripts, ignoring JSON

### DIFF
--- a/Source/Browser/Browser.js
+++ b/Source/Browser/Browser.js
@@ -150,8 +150,10 @@ Browser.exec = function(text){
 
 String.implement('stripScripts', function(exec){
 	var scripts = '';
-	var text = this.replace(/<script[^>]*>([\s\S]*?)<\/script>/gi, function(all, code){
-		scripts += code + '\n';
+	var text = this.replace(/<script([^>]*)>([\s\S]*?)<\/script>/gi, function(all, type, code){
+		if (type == '' || type.indexOf('javascript') != -1){
+			scripts += code + '\n';
+		}
 		return '';
 	});
 	if (exec === true) Browser.exec(scripts);

--- a/Specs/Browser/Browser.js
+++ b/Specs/Browser/Browser.js
@@ -49,6 +49,11 @@ describe('String.stripScripts', function(){
 		expect(window.stripScriptsSpec).to.equal(4242);
 	});
 
+	it('should not execute json scripts', function(){
+		expect('<div><script type="application/json">var stripScriptsSpec424242 = 424242;</script></div>'.stripScripts()).to.equal('<div></div>');
+		expect(window.stripScriptsSpec424242).to.equal(undefined);
+	});
+
 });
 
 describe('Document', function(){

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "grunt-karma": "^2.0.0",
     "grunt-mocha-test": "^0.12.7",
     "grunt-mootools-packager": "^0.4.0",
-    "karma": "^1.7.0",
+    "karma": "^1.7.1",
     "karma-expect": "^1.1",
     "karma-mocha": "^0.2.0",
     "karma-phantomjs-launcher": "^1.0.4",


### PR DESCRIPTION
Currently Mootools tries to execute all scripts, including application/json types, which apparently cause subsequent scripts to fail. 

Noticed such behavior after updating to Joomla 3.19.15 with SqueezeBox plugin with ajax and script enabled options. 