### PR TITLE
Remove the Type object from the public API

### DIFF
--- a/Source/Core/Core.js
+++ b/Source/Core/Core.js
@@ -169,7 +169,7 @@ Function.implement({
 
 // Type
 
-var Type = this.Type = function(name, object){
+var Type = function(name, object){
 	if (name){
 		var lower = name.toLowerCase();
 		var typeCheck = function(item){


### PR DESCRIPTION
First, I want to congratulate you all on working so hard for making this great library.

# Summary

When I was looking in the [Core.js](https://github.com/mootools/mootools-core/blob/master/Source/Core/Core.js) I've noticed that the [`Type` ](https://github.com/mootools/mootools-core/blob/187a16bae2d7144ea4b81aa5c0586498f0fe17c7/Source/Core/Core.js#L172)object is not mentioned in the Mootools official [documentation](https://mootools.net/core/docs/1.6.0/Core/Core) in the core section (except once used in one example on the [Array page](https://mootools.net/core/docs/1.6.0/Types/Array#Array:link)), although it is available to the end-users. The `Type` object offers only the [`Type.is[Type]`](https://github.com/mootools/mootools-core/blob/187a16bae2d7144ea4b81aa5c0586498f0fe17c7/Source/Core/Core.js#L179) functions to check the passed object type, which can be achieved using the Mootools [`typeOf` ](https://github.com/mootools/mootools-core/blob/187a16bae2d7144ea4b81aa5c0586498f0fe17c7/Source/Core/Core.js#L32)function or even using the [`TypeInstance.$family`](https://github.com/mootools/mootools-core/blob/187a16bae2d7144ea4b81aa5c0586498f0fe17c7/Source/Core/Core.js#L181) function that injected to all the native JavaScript types defined by ECMA spec.

# Suggestion
 The `Type` object must be for the internal usage only, In order to clear up any confusion for library users.